### PR TITLE
fix: App does not crash after pressing send button multiple number of times.

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -27,10 +27,13 @@ import com.nilhcem.blenamebadge.device.model.DataToSend
 import com.nilhcem.blenamebadge.device.model.Message
 import com.nilhcem.blenamebadge.device.model.Mode
 import com.nilhcem.blenamebadge.device.model.Speed
+import java.util.Timer
+import java.util.TimerTask
 
 class MessageActivity : AppCompatActivity() {
 
     companion object {
+        private const val SCAN_TIMEOUT_MS = 10_000L
         private const val REQUEST_ENABLE_BT = 1
         private const val REQUEST_PERMISSION_LOCATION = 1
     }
@@ -54,6 +57,13 @@ class MessageActivity : AppCompatActivity() {
 
         send.setOnClickListener {
             // Easter egg
+            send.isClickable = false
+            val buttonTimer = Timer()
+            buttonTimer.schedule(object : TimerTask() {
+                override fun run() {
+                    runOnUiThread { send.isClickable = true }
+                }
+            }, SCAN_TIMEOUT_MS)
             if (content.text.isEmpty()) {
                 presenter.sendBitmap(this, BitmapFactory.decodeResource(resources, R.drawable.mix2))
             } else {


### PR DESCRIPTION
Fixes #32 

Changes: App does not crash after pressing send button multiple number of times when there is no device connected. A toast is shown.

Screenshots for the change:

![screencap](https://user-images.githubusercontent.com/41234408/53470906-17753a80-3a89-11e9-956d-8067959cfb49.png)
