### PR TITLE
fix: Spinner item's width is not till the end

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -51,7 +51,7 @@ class MessageActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.message_activity)
 
-        val spinnerItem = android.R.layout.simple_spinner_dropdown_item
+        val spinnerItem = R.layout.spinner_item
         speed.adapter = ArrayAdapter<String>(this, spinnerItem, Speed.values().mapIndexed { index, _ -> (index + 1).toString() })
         mode.adapter = ArrayAdapter<String>(this, spinnerItem, Mode.values().map { getString(it.stringResId) })
 

--- a/app/src/main/res/layout/spinner_item.xml
+++ b/app/src/main/res/layout/spinner_item.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp"
+    android:textSize="18sp">
+</TextView>


### PR DESCRIPTION
Fixes #36 

The issue is becasue of the usage of default android simple spinner item layout. So instead of that, a custom spinner item layout is made with the width till the end, making the items easier to click.

Screenshots for the change:

![spinner-item-pr](https://user-images.githubusercontent.com/26673203/53760049-c7aecd00-3ee7-11e9-81d4-a294b9ae33d0.gif)
