### PR TITLE
fix: Keyboard goes down when send button is pressed.

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -13,6 +13,7 @@ import android.os.Bundle
 import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
+import android.view.inputmethod.InputMethodManager
 import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.CheckBox
@@ -56,6 +57,9 @@ class MessageActivity : AppCompatActivity() {
         mode.adapter = ArrayAdapter<String>(this, spinnerItem, Mode.values().map { getString(it.stringResId) })
 
         send.setOnClickListener {
+            val inputManager: InputMethodManager = this?.getSystemService(Context.INPUT_METHOD_SERVICE)
+                    as InputMethodManager
+            inputManager.hideSoftInputFromWindow(content.windowToken, InputMethodManager.SHOW_FORCED)
             // Easter egg
             send.isClickable = false
             val buttonTimer = Timer()


### PR DESCRIPTION
Fixes #45 

Changes: When the send button is clicked, the keyboard goes down automatically. When the edit text is pressed again, the keyboard pops up again.

GIF for the change:

![ezgif com-video-to-gif 13](https://user-images.githubusercontent.com/41234408/53821727-5e38c800-3f94-11e9-8bdf-633f99cf1741.gif)
