### PR TITLE
fix: Close keyboard whenever send button is clicked

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -57,10 +57,11 @@ class MessageActivity : AppCompatActivity() {
         mode.adapter = ArrayAdapter<String>(this, spinnerItem, Mode.values().map { getString(it.stringResId) })
 
         send.setOnClickListener {
+            val inputManager: InputMethodManager = this?.getSystemService(Context.INPUT_METHOD_SERVICE)
+                    as InputMethodManager
+            inputManager.hideSoftInputFromWindow(content.windowToken, InputMethodManager.SHOW_FORCED)
+
             if (BluetoothAdapter.getDefaultAdapter().isEnabled) {
-                val inputManager: InputMethodManager = this?.getSystemService(Context.INPUT_METHOD_SERVICE)
-                        as InputMethodManager
-                inputManager.hideSoftInputFromWindow(content.windowToken, InputMethodManager.SHOW_FORCED)
                 // Easter egg
                 send.isClickable = false
                 val buttonTimer = Timer()


### PR DESCRIPTION
Fixes #67 

Changes: 

Now, keyboard would close whenever the send button is clicked, even when bluetooth is off.