### PR TITLE
fix: Button disabled instead of being non-clickable.

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -63,11 +63,11 @@ class MessageActivity : AppCompatActivity() {
 
             if (BluetoothAdapter.getDefaultAdapter().isEnabled) {
                 // Easter egg
-                send.isClickable = false
+                send.isEnabled = false
                 val buttonTimer = Timer()
                 buttonTimer.schedule(object : TimerTask() {
                     override fun run() {
-                        runOnUiThread { send.isClickable = true }
+                        runOnUiThread { send.isEnabled = true }
                     }
                 }, SCAN_TIMEOUT_MS)
                 if (content.text.isEmpty()) {


### PR DESCRIPTION
Fixes #74 

Changes: The send button is now disabled for 10s after being clicked and is then enabled again instead of being non-clickable.

GIF for the change:

![ezgif com-video-to-gif (15)](https://user-images.githubusercontent.com/41234408/54797952-565b7200-4c7c-11e9-82ee-a34f81f1ba4d.gif)
