### PR TITLE
fix: Added option to exit the app 

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -127,6 +127,9 @@ class MessageActivity : AppCompatActivity() {
         builder.setPositiveButton("OK") { _, _ ->
             prepareForScan()
         }
+        builder.setNegativeButton("EXIT") { _, _ ->
+            finish()
+        }
         builder.create().show()
     }
 


### PR DESCRIPTION
Fixes #57 

Changes: The user can now exit the app by pressing exit in the dialog if the user does not want to provide Bluetooth permission.

Screenshots for the change:

![screencap](https://user-images.githubusercontent.com/41234408/54799956-7c394480-4c85-11e9-8736-7f18a26fe5a9.png)

