### PR TITLE
To Implement a badge preview on the top of the screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,7 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildTypes {

--- a/app/src/main/java/com/nilhcem/blenamebadge/device/DataToByteArrayConverter.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/device/DataToByteArrayConverter.kt
@@ -14,7 +14,7 @@ object DataToByteArrayConverter {
     private const val PACKET_START = "77616E670000"
     private const val PACKET_BYTE_SIZE = 16
 
-    private val CHAR_CODES = mapOf(
+    public val CHAR_CODES = mapOf(
             '0' to "007CC6CEDEF6E6C6C67C00",
             '1' to "0018387818181818187E00",
             '2' to "007CC6060C183060C6FE00",

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/Cell.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/Cell.kt
@@ -1,0 +1,8 @@
+package com.nilhcem.blenamebadge.ui.badge_preview
+
+import android.graphics.Rect
+import java.util.ArrayList
+
+internal class Cell {
+    var list: ArrayList<Rect> = ArrayList()
+}

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/CheckList.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/CheckList.kt
@@ -1,0 +1,7 @@
+package com.nilhcem.blenamebadge.ui.badge_preview
+
+import java.util.ArrayList
+
+internal class CheckList {
+    var list: ArrayList<Boolean> = ArrayList()
+}

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
@@ -1,0 +1,144 @@
+package com.nilhcem.blenamebadge.ui.badge_preview
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.RectF
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Color
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.support.annotation.Nullable
+import android.util.AttributeSet
+import android.view.View
+import com.nilhcem.blenamebadge.R
+
+import java.math.BigInteger
+import java.util.ArrayList
+
+class PreviewBadge : View {
+    private var ledDisabled: Drawable? = null
+    private var ledEnabled: Drawable? = null
+
+    private lateinit var bgBounds: RectF
+    private var cells = ArrayList<Cell>()
+
+    private var badgeHeight = 11
+    private var badgeWidth = 44
+
+    private var checkList: ArrayList<CheckList>? = null
+
+    private fun resetCheckList() {
+        checkList = ArrayList()
+        for (i in 0 until badgeHeight) {
+            checkList?.add(CheckList())
+        }
+    }
+
+    constructor(context: Context) : super(context) {
+        ledDisabled = context.resources.getDrawable(R.drawable.ic_led)
+        ledEnabled = context.resources.getDrawable(R.drawable.ic_led_lit)
+
+        if (checkList == null)
+            resetCheckList()
+    }
+
+    constructor(context: Context, @Nullable attrs: AttributeSet) : super(context, attrs) {
+        ledDisabled = context.resources.getDrawable(R.drawable.ic_led)
+        ledEnabled = context.resources.getDrawable(R.drawable.ic_led_lit)
+
+        if (checkList == null)
+            resetCheckList()
+    }
+
+    constructor(context: Context, @Nullable attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+        ledDisabled = context.resources.getDrawable(R.drawable.ic_led)
+        ledEnabled = context.resources.getDrawable(R.drawable.ic_led_lit)
+
+        if (checkList == null)
+            resetCheckList()
+    }
+
+    @SuppressLint("DrawAllocation")
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+
+        val offset = 30
+        bgBounds = RectF((left + offset).toFloat(), (top + offset).toFloat(), (right - offset).toFloat(), (bottom - offset).toFloat())
+
+        val singleCell = (right - left - offset * 2 - 10) / badgeWidth
+
+        cells = ArrayList()
+        for (i in 0 until badgeHeight) {
+            cells.add(Cell())
+            for (j in 0 until badgeWidth) {
+                cells[i].list.add(Rect(
+                        left + offset + 25 + j * singleCell,
+                        top + offset + 25 + i * singleCell,
+                        left + offset + 25 + j * singleCell + singleCell,
+                        top + offset + 25 + i * singleCell + singleCell
+                ))
+            }
+        }
+    }
+
+    @SuppressLint("DrawAllocation")
+    override fun onDraw(canvas: Canvas) {
+        // Paint Configuration
+        val bgPaint = Paint()
+        bgPaint.isAntiAlias = true
+        bgPaint.color = Color.parseColor("#000000")
+
+        // Draw Background
+        canvas.drawRoundRect(bgBounds, 25f, 25f, bgPaint)
+
+        // Draw Cells
+        for (i in 0 until badgeHeight) {
+            for (j in 0 until badgeWidth) {
+                if (i < checkList?.size ?: -1 && j < checkList?.get(i)?.list?.size ?: -1 && checkList?.get(i)?.list?.get(j) == true) {
+                    ledEnabled?.bounds = cells[i].list[j]
+                    ledEnabled?.draw(canvas)
+                } else {
+                    ledDisabled?.bounds = cells[i].list[j]
+                    ledDisabled?.draw(canvas)
+                }
+            }
+        }
+        super.onDraw(canvas)
+    }
+
+    fun setValue(allHex: ArrayList<String>) {
+        resetCheckList()
+
+        if (allHex.size > 0 && 8 * allHex.size < badgeWidth) {
+            val diff = ((badgeWidth - (8 * allHex.size)) / 2)
+            for (i in 0 until badgeHeight) {
+                for (j in 0..diff) {
+                    checkList?.get(i)?.list?.add(false)
+                }
+            }
+        }
+
+        for (hex in allHex) {
+            for (i in 0 until badgeHeight) {
+                val bin = hexToBin(hex.substring(i * 2, i * 2 + 2))
+                for (j in 0..7) {
+                    checkList?.get(i)?.list?.add(Character.getNumericValue(bin[j]) == 1)
+                }
+            }
+        }
+        invalidate()
+    }
+
+    companion object {
+
+        internal fun hexToBin(s: String): String {
+            val number = BigInteger(s, 16).toString(2)
+            val sb = StringBuilder(number)
+            for (i in 0 until 8 - number.length) {
+                sb.insert(0, "0")
+            }
+            return sb.toString()
+        }
+    }
+}

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -28,6 +28,7 @@ import com.nilhcem.blenamebadge.device.model.DataToSend
 import com.nilhcem.blenamebadge.device.model.Message
 import com.nilhcem.blenamebadge.device.model.Mode
 import com.nilhcem.blenamebadge.device.model.Speed
+import com.nilhcem.blenamebadge.ui.badge_preview.PreviewBadge
 import java.util.Timer
 import java.util.TimerTask
 
@@ -45,6 +46,9 @@ class MessageActivity : AppCompatActivity() {
     private val speed: Spinner by bindView(R.id.speed)
     private val mode: Spinner by bindView(R.id.mode)
     private val send: Button by bindView(R.id.send_button)
+    private val previewButton: Button by bindView(R.id.preview_button)
+
+    private val previewBadge: PreviewBadge by bindView(R.id.preview_badge)
 
     private val presenter by lazy { MessagePresenter() }
 
@@ -79,6 +83,13 @@ class MessageActivity : AppCompatActivity() {
                 Toast.makeText(this, getString(R.string.txt_turn_on_bluetooth), Toast.LENGTH_LONG).show()
             }
         }
+
+        previewButton.setOnClickListener {
+            if (!content.text.isEmpty()) {
+                previewBadge.setValue(presenter.convertToPreview(content.text.toString()))
+            }
+        }
+
         prepareForScan()
     }
 

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessagePresenter.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessagePresenter.kt
@@ -30,6 +30,14 @@ class MessagePresenter {
         gattClient.stopClient()
     }
 
+    fun convertToPreview(data: String): ArrayList<String> {
+        val list: ArrayList<String> = ArrayList()
+        for (letter in data) {
+            list.add(DataToByteArrayConverter.CHAR_CODES.getValue(letter))
+        }
+        return list
+    }
+
     private fun sendBytes(context: Context, byteData: List<ByteArray>) {
         Timber.i { "ByteData: ${byteData.map { ByteArrayUtils.byteArrayToHexString(it) }}" }
 

--- a/app/src/main/res/drawable/ic_led.xml
+++ b/app/src/main/res/drawable/ic_led.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp"
+        android:viewportHeight="256" android:viewportWidth="256" android:width="24dp">
+    <path android:fillColor="#d0313131"
+          android:pathData="M74.2,247.3c-22,-22.6 -43.5,-44.7 -65.6,-67.3c58,-56.4 115.8,-112.7 174.1,-169.3c21.8,22.4 43.4,44.6 65.6,67.3C190.3,134.4 132.5,190.7 74.2,247.3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_led_lit.xml
+++ b/app/src/main/res/drawable/ic_led_lit.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp"
+        android:viewportHeight="256" android:viewportWidth="256" android:width="24dp">
+    <path android:fillColor="@color/colorAccent"
+          android:pathData="M74.2,247.3c-22,-22.6 -43.5,-44.7 -65.6,-67.3c58,-56.4 115.8,-112.7 174.1,-169.3c21.8,22.4 43.4,44.6 65.6,67.3C190.3,134.4 132.5,190.7 74.2,247.3z"/>
+</vector>

--- a/app/src/main/res/layout/message_activity.xml
+++ b/app/src/main/res/layout/message_activity.xml
@@ -4,110 +4,134 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.constraint.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/text_to_send_label"
-            android:layout_width="0dp"
+        <com.nilhcem.blenamebadge.ui.badge_preview.PreviewBadge
+            android:layout_width="match_parent"
+            android:id="@+id/preview_badge"
+            android:layout_height="135dp" />
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:fontFamily="sans-serif-condensed"
-            android:text="@string/text_to_send"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            android:typeface="normal"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:padding="16dp">
 
-        <EditText
-            android:id="@+id/text_to_send"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:inputType="text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_to_send_label" />
+            <TextView
+                android:id="@+id/text_to_send_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-condensed"
+                android:text="@string/text_to_send"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:typeface="normal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/speed_label"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:fontFamily="sans-serif-condensed"
-            android:text="@string/speed"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            android:typeface="normal"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_to_send" />
 
-        <Spinner
-            android:id="@+id/speed"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/speed_label" />
+            <EditText
+                android:id="@+id/text_to_send"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:inputType="text"
+                app:layout_constraintEnd_toStartOf="@id/preview_button"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_to_send_label" />
 
-        <TextView
-            android:id="@+id/mode_label"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:fontFamily="sans-serif-condensed"
-            android:text="@string/mode"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            android:typeface="normal"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/speed" />
+            <Button
+                android:id="@+id/preview_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:paddingLeft="42dp"
+                android:paddingRight="42dp"
+                android:text="@string/preview_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintTop_toBottomOf="@+id/text_to_send_label" />
 
-        <Spinner
-            android:id="@+id/mode"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/mode_label" />
+            <TextView
+                android:id="@+id/speed_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="sans-serif-condensed"
+                android:text="@string/speed"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:typeface="normal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_to_send" />
 
-        <CheckBox
-            android:id="@+id/flash"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:text="@string/flash"
-            app:layout_constraintEnd_toStartOf="@+id/marquee"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/mode" />
+            <Spinner
+                android:id="@+id/speed"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/speed_label" />
 
-        <CheckBox
-            android:id="@+id/marquee"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:text="@string/marquee"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/flash"
-            app:layout_constraintTop_toBottomOf="@+id/mode" />
+            <TextView
+                android:id="@+id/mode_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="sans-serif-condensed"
+                android:text="@string/mode"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:typeface="normal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/speed" />
 
-        <Button
-            android:id="@+id/send_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:paddingLeft="42dp"
-            android:paddingRight="42dp"
-            android:text="@string/send_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/flash" />
+            <Spinner
+                android:id="@+id/mode"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/mode_label" />
 
-    </android.support.constraint.ConstraintLayout>
+            <CheckBox
+                android:id="@+id/flash"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/flash"
+                app:layout_constraintEnd_toStartOf="@+id/marquee"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/mode" />
+
+            <CheckBox
+                android:id="@+id/marquee"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/marquee"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/flash"
+                app:layout_constraintTop_toBottomOf="@+id/mode" />
+
+            <Button
+                android:id="@+id/send_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:paddingLeft="42dp"
+                android:paddingRight="42dp"
+                android:text="@string/send_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/flash" />
+
+        </android.support.constraint.ConstraintLayout>
+    </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="mode_animation">Animation</string>
     <string name="mode_laser">Laser</string>
     <string name="send_button">SEND</string>
+    <string name="preview_button">PREVIEW</string>
     <string name="permission_required">Permission required</string>
     <string name="txt_turn_on_bluetooth">Turn on Bluetooth and try again</string>
 </resources>


### PR DESCRIPTION
Fixes #14 
Motive : Implement a badge preview on the top of the screen
Changes: 
- Created a Custom View (PreviewBadge.kt) for getting the complete visual of an Actual LED
- Added seperate data classes(Cell.kt, CheckList.kt) for better management
- Changes to MessageActivity to incorporate Support for Badge
- Vector Drawable's for LED
- Added Function in Presenter(MessagePresenter.kt) to take care of the hex conversions
- Changes to Message Activity XML

Screenshots of the changes:
![Screenshot_20190325-144859_Badge Magic](https://user-images.githubusercontent.com/11988517/54970801-aa7e9300-4fa9-11e9-979f-7dc09b96beb3.jpg)
![Screenshot_20190325-144909_Badge Magic](https://user-images.githubusercontent.com/11988517/54970806-b1a5a100-4fa9-11e9-848b-b8ebc7ea90d6.jpg)
