### PR TITLE
fix: A toast is displayed when no device is found.

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessagePresenter.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessagePresenter.kt
@@ -2,6 +2,8 @@ package com.nilhcem.blenamebadge.ui.message
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.widget.Toast
+import com.nilhcem.blenamebadge.R
 import com.nilhcem.blenamebadge.core.android.log.Timber
 import com.nilhcem.blenamebadge.core.utils.ByteArrayUtils
 import com.nilhcem.blenamebadge.device.DataToByteArrayConverter
@@ -44,6 +46,7 @@ class MessagePresenter {
         scanHelper.startLeScan { device ->
             if (device == null) {
                 Timber.e { "Scan could not find any device" }
+                Toast.makeText(context, R.string.no_device_found, Toast.LENGTH_SHORT).show()
             } else {
                 Timber.e { "Device found: $device" }
 
@@ -53,6 +56,8 @@ class MessagePresenter {
                             Timber.i { "Data sent" }
                             gattClient.stopClient()
                         }
+                    } else {
+                        Toast.makeText(context, R.string.no_device_found, Toast.LENGTH_SHORT).show()
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="preview_button">PREVIEW</string>
     <string name="permission_required">Permission required</string>
     <string name="txt_turn_on_bluetooth">Turn on Bluetooth and try again</string>
+    <string name="no_device_found">No device found. Please try again.</string>
 </resources>


### PR DESCRIPTION
Fixes #42 

Changes: A toast is shown if no compatible device is found after scanning.

Screenshots for the change:

![screencap](https://user-images.githubusercontent.com/41234408/55058367-c8272780-5091-11e9-86fa-f189500de1d2.png)
