### PR TITLE
fix: Fix height of preview badge in landscape mode.

### DIFF
--- a/app/src/main/res/layout/message_activity.xml
+++ b/app/src/main/res/layout/message_activity.xml
@@ -12,7 +12,7 @@
         <com.nilhcem.blenamebadge.ui.badge_preview.PreviewBadge
             android:id="@+id/preview_badge"
             android:layout_width="match_parent"
-            android:layout_height="135dp" />
+            android:layout_height="@dimen/preview_height" />
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -3,5 +3,5 @@
     <dimen name="square_image_dimension">64dp</dimen>
     <dimen name="card_radius">10dp</dimen>
     <dimen name="card_elevation">4dp</dimen>
-    <dimen name="preview_height">135dp</dimen>
+    <dimen name="preview_height">230dp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #106 
Changes: Fixed the height of the preview badge in landscape mode.

Screenshots for the change:

![image](https://user-images.githubusercontent.com/41234408/55281307-664c1380-5358-11e9-87be-00a3b3d80d69.png)
