### PR TITLE
Fix typo in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Security in Bluetooth LE devices is optional, and many cheap products you can fi
 
 As we understand how the Bluetooth LED badge works, converting a text to multiple byte arrays, we can send using the Bluetooth LE APIs. An indepth blog post about reverse-engineering the Bluetooth community [is here](http://nilhcem.com/iot/reverse-engineering-bluetooth-led-name-badge). 
 
-The implementation in the Android app consists of manipulating bits. That may be tricky. A single bit error and nothing will work, plus it will be hard to debug. For those reasons, and since the specs are perfectly clear the reverse engeineer Gautier Mechling strongly recommendeds to start writing unit tests before the code implementation. 
+The implementation in the Android app consists of manipulating bits. That may be tricky. A single bit error and nothing will work, plus it will be hard to debug. For those reasons, and since the specs are perfectly clear the reverse engineer Gautier Mechling strongly recommends to start writing unit tests before the code implementation. 
 
 ## Available Devices
 


### PR DESCRIPTION
### Fixes #112 

### Changes: 
Fix the typos in the readme file:
- engeineer-> engineer
- recomendeds->recommends

### Screenshots for the change:
![4](https://user-images.githubusercontent.com/35539313/55288567-02b4fb00-53d7-11e9-856b-57d3c175f0ef.png)
