### PR TITLE
fix: Prevented the app from crashing when a non-implemented character is entered.

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -112,9 +112,13 @@ class MessageActivity : AppCompatActivity() {
         }
 
         previewButton.setOnClickListener {
+            val (valid, textToSend) = presenter.convertToPreview(if (!content.text.isEmpty()) content.text.toString() else " ")
+            if (!valid) {
+                Toast.makeText(baseContext, R.string.character_not_found, Toast.LENGTH_SHORT).show()
+            }
             if (!content.text.isEmpty()) {
                 previewBadge.setValue(
-                        presenter.convertToPreview(content.text.toString()),
+                        textToSend,
                         marquee.isChecked,
                         flash.isChecked,
                         Speed.values()[speed.selectedItemPosition],

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessagePresenter.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessagePresenter.kt
@@ -32,12 +32,17 @@ class MessagePresenter {
         gattClient.stopClient()
     }
 
-    fun convertToPreview(data: String): List<String> {
+    fun convertToPreview(data: String): Pair<Boolean, List<String>> {
+        var valid = true
         val list = mutableListOf<String>()
         for (letter in data) {
-            list.add(DataToByteArrayConverter.CHAR_CODES.getValue(letter))
+            if (DataToByteArrayConverter.CHAR_CODES.containsKey(letter)) {
+                list.add(DataToByteArrayConverter.CHAR_CODES.getValue(letter))
+            } else {
+                valid = false
+            }
         }
-        return list
+        return Pair(valid, list)
     }
 
     private fun sendBytes(context: Context, byteData: List<ByteArray>) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,5 @@
     <string name="no_device_found">No device found. Please try again.</string>
     <string name="select_drawable_text">Select Drawable:</string>
     <string name="select_drawable">Please select Drawable to be previewed</string>
+    <string name="character_not_found">Some of the character(s) entered cannot be displayed.</string>
 </resources>


### PR DESCRIPTION
Fixes #97 

Changes: The app does not crash when a non-implemented character is previewed and a toast is shown.

GIF for the change:

![ezgif com-video-to-gif (16)](https://user-images.githubusercontent.com/41234408/55404624-f3b87f00-5575-11e9-9ab5-303c03b1f825.gif)
