### PR TITLE
fix: Enable flash on left/right/up/down animation

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
@@ -131,147 +131,101 @@ class PreviewBadge : View {
         // Draw Cells
         for (i in 0 until badgeHeight) {
             for (j in 0 until badgeWidth) {
+                var flashLEDOn = true
                 if (ifFlash) {
-                    val aI: Int = animationIndex % 800
-                    val valid: Boolean = aI > 400
-
-                    if (valid && i < checkList.size && j < checkList[i].list.size && checkList[i].list[j]) {
-                        ledEnabled.bounds = cells[i].list[j]
-                        ledEnabled.draw(canvas)
-                    } else {
-                        ledDisabled.bounds = cells[i].list[j]
-                        ledDisabled.draw(canvas)
-                    }
-                } else if (ifMarquee) {
-                    val aI: Int = animationIndex.div(200)
-                    val valid: Boolean = if (i == 0 || j == 0 || i == badgeHeight - 1 || j == badgeWidth - 1) {
+                    val aIFlash = animationIndex % 800
+                    flashLEDOn = aIFlash > 400
+                }
+                var validMarquee = false
+                if (ifMarquee) {
+                    val aIMarquee = animationIndex.div(200)
+                    validMarquee = if (i == 0 || j == 0 || i == badgeHeight - 1 || j == badgeWidth - 1) {
                         if ((i == 0 || j == badgeWidth - 1) && !(i == badgeHeight - 1 && j == badgeWidth - 1)) {
-                            (i + j) % 4 == (aI % 4)
+                            (i + j) % 4 == (aIMarquee % 4)
                         } else {
-                            (i + j - 1) % 4 == (3 - (aI % 4))
+                            (i + j - 1) % 4 == (3 - (aIMarquee % 4))
                         }
                     } else {
                         false
                     }
+                }
 
-                    when (badgeMode) {
-                        Mode.LEFT -> {
-                            val animationValue = animationIndex.div(200)
-                            if (valid || i < checkList.size && j < checkList[i].list.size && j >= animationValue && checkList[i].list[j - animationValue]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
-                        }
-                        Mode.RIGHT -> {
-                            val animationValue = animationIndex.div(200)
-                            if (valid || i < checkList.size && j < checkList[i].list.size && j <= (43 - animationValue) && checkList[i].list[(animationValue.plus(j))]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
-                        }
-                        Mode.UP -> {
-                            val animationValue = animationIndex.div(800)
-                            if (!(!valid && !(i < checkList.size && j < checkList[i].list.size && i >= animationValue && checkList[i - animationValue].list[j]))) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
-                        }
-                        Mode.DOWN -> {
-                            val animationValue = animationIndex.div(800)
-                            if (valid || i < checkList.size && j < checkList[i].list.size && i <= (10 - animationValue) && checkList[animationValue.plus(i)].list[j]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
-                        }
-                        Mode.FIXED -> {
-                            if (valid || i < checkList.size && j < checkList[i].list.size && checkList[i].list[j]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
-                        }
-                        Mode.SNOWFLAKE -> {
-                        }
-                        Mode.PICTURE -> {
-                        }
-                        Mode.ANIMATION -> {
-                        }
-                        Mode.LASER -> {
+                when (badgeMode) {
+                    Mode.LEFT -> {
+                        val animationValue = animationIndex.div(200)
+                        if (validMarquee || flashLEDOn
+                                && i < checkList.size
+                                && j < checkList[i].list.size
+                                && j >= animationValue
+                                && checkList[i].list[j - animationValue]) {
+                            ledEnabled.bounds = cells[i].list[j]
+                            ledEnabled.draw(canvas)
+                        } else {
+                            ledDisabled.bounds = cells[i].list[j]
+                            ledDisabled.draw(canvas)
                         }
                     }
-                } else {
-                    when (badgeMode) {
-                        Mode.LEFT -> {
-                            val animationValue = animationIndex.div(200)
-                            if (i < checkList.size && j < checkList[i].list.size && j >= animationValue && checkList[i].list[j - animationValue]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
+                    Mode.RIGHT -> {
+                        val animationValue = animationIndex.div(200)
+                        if (validMarquee || flashLEDOn
+                                && i < checkList.size
+                                && j < checkList[i].list.size
+                                && j <= (43 - animationValue)
+                                && checkList[i].list[(animationValue.plus(j))]) {
+                            ledEnabled.bounds = cells[i].list[j]
+                            ledEnabled.draw(canvas)
+                        } else {
+                            ledDisabled.bounds = cells[i].list[j]
+                            ledDisabled.draw(canvas)
                         }
-                        Mode.RIGHT -> {
-                            val animationValue = animationIndex.div(200)
-                            if (i < checkList.size && j < checkList[i].list.size && j <= (43 - animationValue) && checkList[i].list[(animationValue.plus(j))]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
+                    }
+                    Mode.UP -> {
+                        val animationValue = animationIndex.div(800)
+                        if (validMarquee || flashLEDOn
+                                && i < checkList.size
+                                && j < checkList[i].list.size
+                                && i >= animationValue
+                                && checkList[i - animationValue].list[j]) {
+                            ledEnabled.bounds = cells[i].list[j]
+                            ledEnabled.draw(canvas)
+                        } else {
+                            ledDisabled.bounds = cells[i].list[j]
+                            ledDisabled.draw(canvas)
                         }
-                        Mode.UP -> {
-                            val animationValue = animationIndex.div(800)
-                            if (i < checkList.size && j < checkList[i].list.size && i >= animationValue && checkList[i - animationValue].list[j]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
+                    }
+                    Mode.DOWN -> {
+                        val animationValue = animationIndex.div(800)
+                        if (validMarquee || flashLEDOn
+                                && i < checkList.size
+                                && j < checkList[i].list.size
+                                && i <= (10 - animationValue)
+                                && checkList[animationValue.plus(i)].list[j]) {
+                            ledEnabled.bounds = cells[i].list[j]
+                            ledEnabled.draw(canvas)
+                        } else {
+                            ledDisabled.bounds = cells[i].list[j]
+                            ledDisabled.draw(canvas)
                         }
-                        Mode.DOWN -> {
-                            val animationValue = animationIndex.div(800)
-                            if (i < checkList.size && j < checkList[i].list.size && i <= (10 - animationValue) && checkList[animationValue.plus(i)].list[j]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
+                    }
+                    Mode.FIXED -> {
+                        if (validMarquee || flashLEDOn
+                                && i < checkList.size
+                                && j < checkList[i].list.size
+                                && checkList[i].list[j]) {
+                            ledEnabled.bounds = cells[i].list[j]
+                            ledEnabled.draw(canvas)
+                        } else {
+                            ledDisabled.bounds = cells[i].list[j]
+                            ledDisabled.draw(canvas)
                         }
-                        Mode.FIXED -> {
-                            if (i < checkList.size && j < checkList[i].list.size && checkList[i].list[j]) {
-                                ledEnabled.bounds = cells[i].list[j]
-                                ledEnabled.draw(canvas)
-                            } else {
-                                ledDisabled.bounds = cells[i].list[j]
-                                ledDisabled.draw(canvas)
-                            }
-                        }
-                        Mode.SNOWFLAKE -> {
-                        }
-                        Mode.PICTURE -> {
-                        }
-                        Mode.ANIMATION -> {
-                        }
-                        Mode.LASER -> {
-                        }
+                    }
+                    Mode.SNOWFLAKE -> {
+                    }
+                    Mode.PICTURE -> {
+                    }
+                    Mode.ANIMATION -> {
+                    }
+                    Mode.LASER -> {
                     }
                 }
             }

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
@@ -153,11 +153,11 @@ class PreviewBadge : View {
                 when (badgeMode) {
                     Mode.LEFT -> {
                         val animationValue = animationIndex.div(200)
-                        if (validMarquee || flashLEDOn
-                                && i < checkList.size
-                                && j < checkList[i].list.size
-                                && j >= animationValue
-                                && checkList[i].list[j - animationValue]) {
+                        if (validMarquee || flashLEDOn &&
+                                i < checkList.size &&
+                                j < checkList[i].list.size &&
+                                j >= animationValue &&
+                                checkList[i].list[j - animationValue]) {
                             ledEnabled.bounds = cells[i].list[j]
                             ledEnabled.draw(canvas)
                         } else {
@@ -167,11 +167,11 @@ class PreviewBadge : View {
                     }
                     Mode.RIGHT -> {
                         val animationValue = animationIndex.div(200)
-                        if (validMarquee || flashLEDOn
-                                && i < checkList.size
-                                && j < checkList[i].list.size
-                                && j <= (43 - animationValue)
-                                && checkList[i].list[(animationValue.plus(j))]) {
+                        if (validMarquee || flashLEDOn &&
+                                i < checkList.size &&
+                                j < checkList[i].list.size &&
+                                j <= (43 - animationValue) &&
+                                checkList[i].list[(animationValue.plus(j))]) {
                             ledEnabled.bounds = cells[i].list[j]
                             ledEnabled.draw(canvas)
                         } else {
@@ -181,11 +181,11 @@ class PreviewBadge : View {
                     }
                     Mode.UP -> {
                         val animationValue = animationIndex.div(800)
-                        if (validMarquee || flashLEDOn
-                                && i < checkList.size
-                                && j < checkList[i].list.size
-                                && i >= animationValue
-                                && checkList[i - animationValue].list[j]) {
+                        if (validMarquee || flashLEDOn &&
+                                i < checkList.size &&
+                                j < checkList[i].list.size &&
+                                i >= animationValue &&
+                                checkList[i - animationValue].list[j]) {
                             ledEnabled.bounds = cells[i].list[j]
                             ledEnabled.draw(canvas)
                         } else {
@@ -195,11 +195,11 @@ class PreviewBadge : View {
                     }
                     Mode.DOWN -> {
                         val animationValue = animationIndex.div(800)
-                        if (validMarquee || flashLEDOn
-                                && i < checkList.size
-                                && j < checkList[i].list.size
-                                && i <= (10 - animationValue)
-                                && checkList[animationValue.plus(i)].list[j]) {
+                        if (validMarquee || flashLEDOn &&
+                                i < checkList.size &&
+                                j < checkList[i].list.size &&
+                                i <= (10 - animationValue) &&
+                                checkList[animationValue.plus(i)].list[j]) {
                             ledEnabled.bounds = cells[i].list[j]
                             ledEnabled.draw(canvas)
                         } else {
@@ -208,10 +208,10 @@ class PreviewBadge : View {
                         }
                     }
                     Mode.FIXED -> {
-                        if (validMarquee || flashLEDOn
-                                && i < checkList.size
-                                && j < checkList[i].list.size
-                                && checkList[i].list[j]) {
+                        if (validMarquee || flashLEDOn &&
+                                i < checkList.size &&
+                                j < checkList[i].list.size &&
+                                checkList[i].list[j]) {
                             ledEnabled.bounds = cells[i].list[j]
                             ledEnabled.draw(canvas)
                         } else {


### PR DESCRIPTION
Details:
- Remove long redundant code on setting MODE
- Set the boolean logic for flash so that other animation can works with flash. The boolean flashLEDOn means that when that flag is set to true, the LED works normally, otherwise, all LED is turned off.This flag is only changed when user set pick the ifFlag option

Fixes: #132

Screenshots for the change:
This is the screenshot for RIGHT, other MODE I have tested and it also works fine. The GIF is a little bit unclear on blinking because I think it is already be compressed and some of the frame is cut out.
<img src="https://i.ibb.co/G9TmdGK/ezgif-2-db27a66d3a86.gif" width="300">