### PR TITLE
fix: App crash when edittext is empty

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -91,7 +91,7 @@ class MessageActivity : AppCompatActivity() {
                 }, SCAN_TIMEOUT_MS)
                 if (content.text.isEmpty()) {
                     presenter.sendBitmap(this, BitmapFactory.decodeResource(resources, R.drawable.mix2))
-                    showLoaderView(false)
+                    showLoaderView(true)
                 } else {
                     presenter.sendMessage(this, convertToDeviceDataModel())
                     showLoaderView(true)


### PR DESCRIPTION
Fixes #140 

Changes: If edittext is empty, the loader is still switched on the default bitmap is sent to the device,
