### PR TITLE
fix: Made the default bitmap image appear as preview.

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/adapter/DrawableAdapter.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/adapter/DrawableAdapter.kt
@@ -43,7 +43,11 @@ class DrawableAdapter(private val context: Context, private val list: List<Drawa
 
     fun getSelectedItem(): DrawableInfo? {
         return if (selectedPosition == -1) null else list[selectedPosition]
-    }    
+    }
+
+    fun getDefaultItem(): DrawableInfo {
+        return DrawableInfo(context.resources.getDrawable(R.drawable.mix2))
+    }
 
     override fun getItemCount(): Int {
         return list.size

--- a/app/src/main/java/com/nilhcem/blenamebadge/adapter/DrawableAdapter.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/adapter/DrawableAdapter.kt
@@ -41,8 +41,12 @@ class DrawableAdapter(private val context: Context, private val list: List<Drawa
         }
     }
 
-    fun getSelectedItem(): Any {
-        return if (selectedPosition == -1) -1 else list[selectedPosition]
+    fun getSelectedItem(): DrawableInfo? {
+        return if (selectedPosition == -1) null else list[selectedPosition]
+    }
+
+    fun getDefaultItem(): DrawableInfo {
+        return DrawableInfo(context.resources.getDrawable(R.drawable.mix2))
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
@@ -303,7 +303,7 @@ class PreviewBadge : View {
         }
     }
 
-    fun setValue(allHex: ArrayList<String>, ifMar: Boolean, ifFla: Boolean, speed: Speed, mode: Mode) {
+    fun setValue(allHex: List<String>, ifMar: Boolean, ifFla: Boolean, speed: Speed, mode: Mode) {
         resetCheckList()
         ifMarquee = ifMar
         ifFlash = ifFla

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -112,26 +112,43 @@ class MessageActivity : AppCompatActivity() {
         }
 
         previewButton.setOnClickListener {
-            previewBadge.setValue(
-                    presenter.convertToPreview(if (!content.text.isEmpty()) content.text.toString() else " "),
-                    marquee.isChecked,
-                    flash.isChecked,
-                    Speed.values()[speed.selectedItemPosition],
-                    Mode.values()[mode.selectedItemPosition]
-            )
+            if (!content.text.isEmpty()) {
+                previewBadge.setValue(
+                        presenter.convertToPreview(content.text.toString()),
+                        marquee.isChecked,
+                        flash.isChecked,
+                        Speed.values()[speed.selectedItemPosition],
+                        Mode.values()[mode.selectedItemPosition]
+                )
+            } else {
+                previewBadge.setValue(
+                        Converters.convertDrawableToLEDHex((drawableRecyclerAdapter.getDefaultItem()).image),
+                        false,
+                        false,
+                        Speed.values()[speed.selectedItemPosition],
+                        Mode.FIXED
+                )
+            }
         }
 
         previewButtonDrawable.setOnClickListener {
-            if (drawableRecyclerAdapter.getSelectedItem() != -1)
+            val selectedItem = drawableRecyclerAdapter.getSelectedItem()
+            if (selectedItem != null)
                 previewBadge.setValue(
-                        Converters.convertDrawableToLEDHex((drawableRecyclerAdapter.getSelectedItem() as DrawableInfo).image) as java.util.ArrayList<String>,
+                        Converters.convertDrawableToLEDHex(selectedItem.image),
                         marquee.isChecked,
                         flash.isChecked,
                         Speed.values()[speed.selectedItemPosition],
                         Mode.values()[mode.selectedItemPosition]
                 )
             else
-                Toast.makeText(this, getString(R.string.select_drawable), Toast.LENGTH_LONG).show()
+                previewBadge.setValue(
+                        Converters.convertDrawableToLEDHex((drawableRecyclerAdapter.getDefaultItem()).image),
+                        false,
+                        false,
+                        Speed.values()[speed.selectedItemPosition],
+                        Mode.FIXED
+                )
         }
 
         setupRecycler()


### PR DESCRIPTION
Fixes #141 

Changes: If the edit text is empty, the default image bitmap image is shown in the preview if clicked by the user.

GIF for the change:

![ezgif com-video-to-gif (17)](https://user-images.githubusercontent.com/41234408/55496140-fc838080-565b-11e9-867c-91fcc41b4128.gif)
