### PR TITLE
fix: scan logic

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/device/bluetooth/ScanHelper.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/device/bluetooth/ScanHelper.kt
@@ -43,7 +43,7 @@ class ScanHelper {
     }
 
     fun startLeScan(onDeviceFoundCallback: ((BluetoothDevice?) -> Unit)) {
-        if (!isScanning) return
+        if (isScanning) return
         this.onDeviceFoundCallback = onDeviceFoundCallback
         isScanning = true
 


### PR DESCRIPTION
Fixes #165 

Changes:
- Change logic from `if(!isScanning)` to `if(isScanning)`

**ScreenShot**
Scan is perfomed . And result is shown now
<img src="https://user-images.githubusercontent.com/24780524/55667179-7d1dc900-5876-11e9-9c89-c11df59e7873.gif" width=360>

**Logs before change**
Scan is not being perfomred
```
2019-04-06 13:15:00.328 30555-30555/com.nilhcem.blenamebadge I/MessagePresenter: ByteData: [77616E67000000000400000000000000, 00050000000000000000000000000000, 000000000000E304060D0F0000000000, 00000000000000000000000000000000, 001E3121033B67430D18133E7F9C082A, 9CFFFFFFFF7F003CC64260EEF3E1D88C, 640000020103060F0B0A010000000810, F8ECFEFA0AB000000000000000000000]
2019-04-06 13:15:00.511 30555-30563/com.nilhcem.blenamebadge I/em.blenamebadg: Compiler allocated 4MB to compile void android.widget.TextView.<init>(android.content.Context, android.util.AttributeSet, int, int)
```

**Logs after change**
Scan is being performed now

```
2019-04-06 13:15:00.328 30555-30555/com.nilhcem.blenamebadge I/MessagePresenter: ByteData: [77616E67000000000400000000000000, 00050000000000000000000000000000, 000000000000E304060D0F0000000000, 00000000000000000000000000000000, 001E3121033B67430D18133E7F9C082A, 9CFFFFFFFF7F003CC64260EEF3E1D88C, 640000020103060F0B0A010000000810, F8ECFEFA0AB000000000000000000000]
2019-04-06 13:15:00.511 30555-30563/com.nilhcem.blenamebadge I/em.blenamebadg: Compiler allocated 4MB to compile void android.widget.TextView.<init>(android.content.Context, android.util.AttributeSet, int, int)
2019-04-06 13:15:10.381 30555-30555/com.nilhcem.blenamebadge I/ScanHelper$stopScanRunnable: No devices found
2019-04-06 13:15:10.391 30555-30555/com.nilhcem.blenamebadge E/MessagePresenter$sendBytes: Scan could not find any device
```

