### PR TITLE
fix: multiple bluetooth dialogs on rotation 

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/message/MessageActivity.kt
@@ -7,6 +7,7 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
 import android.os.Bundle
@@ -57,10 +58,9 @@ class MessageActivity : AppCompatActivity() {
     private val previewButtonDrawable: Button by bindView(R.id.preview_button_drawable)
     private val drawableRecyclerView: RecyclerView by bindView(R.id.recycler_view)
     private val sendByteLoader: ProgressBar by bindView(R.id.sendBytesLoader)
+    private val previewBadge: PreviewBadge by bindView(R.id.preview_badge)
 
     private lateinit var drawableRecyclerAdapter: DrawableAdapter
-
-    private val previewBadge: PreviewBadge by bindView(R.id.preview_badge)
 
     private val presenter by lazy { MessagePresenter() }
 
@@ -190,6 +190,7 @@ class MessageActivity : AppCompatActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == REQUEST_ENABLE_BT) {
+            this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
             if (resultCode == Activity.RESULT_CANCELED) {
                 showAlertDialog(true)
                 return
@@ -260,6 +261,7 @@ class MessageActivity : AppCompatActivity() {
                 }
             } else {
                 val enableBtIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
+                this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
                 startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT)
             }
         } else {


### PR DESCRIPTION
Fixes #101 

Changes: 
- we lock the screen rotation before the intent starts
- we unlock the screen rotation when intent is complete

Additional Context
This bug has been since android 2.2 ( https://issuetracker.google.com/issues/37114831 ). This is a workaround until the android team fixes it