### PR TITLE
fix: animations go on the wrong side of the screen

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/badge_preview/PreviewBadge.kt
@@ -115,8 +115,6 @@ class PreviewBadge : View {
             this.badgeMode = Mode.values()[currentState.getInt(BUNDLE_MODE)]
             this.checkList = currentState.getParcelableArrayList(BUNDLE_CHECKLIST)
 
-            valueAnimator?.cancel()
-
             countFrame = 0
             lastFrame = 0
 
@@ -306,10 +304,11 @@ class PreviewBadge : View {
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        configValueAnimation()
+        configValueAnimation(checkList[0].list.size * 200)
     }
 
     private fun configValueAnimation(valueAnimatorNumber: Int = 8800) {
+        valueAnimator?.cancel()
         valueAnimator = ValueAnimator.ofInt(valueAnimatorNumber - 1, 0).apply {
             addUpdateListener {
                 animationIndex = it.animatedValue as Int
@@ -326,7 +325,6 @@ class PreviewBadge : View {
         resetCheckList()
         ifMarquee = ifMar
         ifFlash = ifFla
-        valueAnimator?.cancel()
 
         badgeMode = mode
         badgeSpeed = when (speed) {


### PR DESCRIPTION
Fixes #159 

Changes: 
- onAttackWindow re-configuration cause the animation to reduce the width by 1/2 

