### PR TITLE
fix: Avoid app crash on saving after screen rotation

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/MainSavedFragment.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/MainSavedFragment.kt
@@ -21,7 +21,7 @@ import com.nilhcem.blenamebadge.device.model.Speed
 import com.nilhcem.blenamebadge.util.Converters
 import com.nilhcem.blenamebadge.util.MoshiUtils
 import com.nilhcem.blenamebadge.util.StorageUtils
-import kotlinx.android.synthetic.main.fragment_main_save.recycler_view
+import kotlinx.android.synthetic.main.fragment_main_save.savedConfigRecyclerView
 import java.io.File
 
 class MainSavedFragment : BaseFragment() {
@@ -81,8 +81,9 @@ class MainSavedFragment : BaseFragment() {
     }
 
     private fun setupRecycler() {
-        recycler_view.adapter = null
-        recycler_view.layoutManager = LinearLayoutManager(context)
+        if (savedConfigRecyclerView == null) return
+        savedConfigRecyclerView.adapter = null
+        savedConfigRecyclerView.layoutManager = LinearLayoutManager(context)
 
         val listOfDrawables = StorageUtils.getAllFiles()
 
@@ -98,7 +99,7 @@ class MainSavedFragment : BaseFragment() {
                     setPreviewNull()
             }
         })
-        recycler_view.adapter = recyclerAdapter
+        savedConfigRecyclerView.adapter = recyclerAdapter
     }
 
     private fun showLoadAlert(item: ConfigInfo) {

--- a/app/src/main/res/layout/fragment_main_save.xml
+++ b/app/src/main/res/layout/fragment_main_save.xml
@@ -15,7 +15,7 @@
         android:typeface="normal" />
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
+        android:id="@+id/savedConfigRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_small">

--- a/app/src/main/res/layout/fragment_main_text.xml
+++ b/app/src/main/res/layout/fragment_main_text.xml
@@ -86,7 +86,7 @@
                         android:layout_height="wrap_content">
 
                         <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/recycler_view"
+                            android:id="@+id/drawablesRecyclerView"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/spacing_small">


### PR DESCRIPTION
Details:
- App crashes because when the screen is rotated, the recycler view is destroyed. This is avoided by setting retainInstance to true in the onCreate() of the fragment
- Changing same id name for different recyclerView
- Currently, saving a configuration is in onPostExecute() of the AsyncTask class, which means that action saving is done in the main thread. I put it back into the doInBackground()

Fixes: #211
