### PR TITLE
fix: If the selected item is deleted, preview is cleared and a toast is displayed

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/MainSavedFragment.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/MainSavedFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.View
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -113,6 +114,8 @@ class MainSavedFragment : BaseFragment() {
                 StorageUtils.deleteFile(item.fileName)
                 setupRecycler()
                 alertDialog.dismiss()
+                setPreviewNull()
+                Toast.makeText(context, R.string.deleted_saved, Toast.LENGTH_SHORT).show()
             }
             alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener {
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="saveactivity_operation_title">Perform Operation</string>
     <string name="delete">DELETE</string>
     <string name="share">SHARE</string>
+    <string name="deleted_saved">Configuration Deleted.</string>
     <string name="file_provider_authority" translatable="false">com.nilhcem.blenamebadge.fileprovider</string>
     <string name="menu_import">Import Badge Configuration</string>
     <string name="invalid_import_json">Select a Valid Badge Magic Configuration</string>


### PR DESCRIPTION
Fixes #215 

Changes: When a saved configuration is deleted, the preview is cleared and a toast is displayed.
