### PR TITLE
fix: Message is shown if edittext is empty.

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/MainSavedFragment.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/MainSavedFragment.kt
@@ -15,6 +15,7 @@ import com.nilhcem.blenamebadge.R
 import com.nilhcem.blenamebadge.adapter.OnSavedItemSelected
 import com.nilhcem.blenamebadge.adapter.SaveAdapter
 import com.nilhcem.blenamebadge.data.ConfigInfo
+import com.nilhcem.blenamebadge.data.DrawableInfo
 import com.nilhcem.blenamebadge.device.model.DataToSend
 import com.nilhcem.blenamebadge.device.model.Message
 import com.nilhcem.blenamebadge.device.model.Mode
@@ -68,15 +69,16 @@ class MainSavedFragment : BaseFragment() {
                 badgeConfig.mode
             )))
         } else {
+            Toast.makeText(context, R.string.no_configuration, Toast.LENGTH_SHORT).show()
             return DataToSend(listOf(Message(
-                Converters.convertTextToLEDHex(
-                    " ",
+                Converters.convertDrawableToLEDHex(
+                    DrawableInfo(resources.getDrawable(R.drawable.mix2)).image,
                     false
-                ).second,
+                ),
                 false,
                 false,
                 Speed.ONE,
-                Mode.LEFT
+                Mode.FIXED
             )))
         }
     }

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/MainTextDrawableFragment.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/MainTextDrawableFragment.kt
@@ -114,10 +114,13 @@ class MainTextDrawableFragment : BaseFragment() {
     }
 
     private fun convertBitmapToDeviceDataModel(): DataToSend {
+        if (drawableRecyclerAdapter.getSelectedItem() == null) {
+            Toast.makeText(context, R.string.no_drawable, Toast.LENGTH_SHORT).show()
+        }
         return DataToSend(listOf(Message(
             Converters.convertDrawableToLEDHex(
                 drawableRecyclerAdapter.getSelectedItem()?.image
-                    ?: resources.getDrawable(R.drawable.apple),
+                    ?: resources.getDrawable(R.drawable.mix2),
                 invertLED.isChecked),
             flash.isChecked,
             marquee.isChecked,

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/main/MainActivity.kt
@@ -30,6 +30,7 @@ import com.nilhcem.blenamebadge.ui.fragments.MainTextDrawableFragment
 import com.nilhcem.blenamebadge.ui.interfaces.PreviewChangeListener
 import com.nilhcem.blenamebadge.util.StorageUtils
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.fragment_main_text.*
 import java.util.Timer
 import java.util.TimerTask
 
@@ -66,20 +67,24 @@ class MainActivity : AppCompatActivity(), PreviewChangeListener {
         if (bluetoothPresent)
             fab_main.setOnClickListener {
                 if (BluetoothAdapter.getDefaultAdapter().isEnabled) {
-                    // Easter egg
-                    Toast.makeText(this, getString(R.string.sending_data), Toast.LENGTH_LONG).show()
-                    startFabAnimation()
+                    if (viewPager.currentItem == 0 && textRadio.isChecked && text_to_send.text.isEmpty()) {
+                        Toast.makeText(this, getString(R.string.empty_edittext), Toast.LENGTH_SHORT).show()
+                    } else {
+                        // Easter egg
+                        Toast.makeText(this, getString(R.string.sending_data), Toast.LENGTH_LONG).show()
+                        startFabAnimation()
 
-                    val buttonTimer = Timer()
-                    buttonTimer.schedule(object : TimerTask() {
-                        override fun run() {
-                            runOnUiThread {
-                                endFabAnimation()
+                        val buttonTimer = Timer()
+                        buttonTimer.schedule(object : TimerTask() {
+                            override fun run() {
+                                runOnUiThread {
+                                    endFabAnimation()
+                                }
                             }
-                        }
-                    }, SCAN_TIMEOUT_MS)
+                        }, SCAN_TIMEOUT_MS)
 
-                    presenter.sendMessage(this, fragmentList[viewPager.currentItem].getSendData())
+                        presenter.sendMessage(this, fragmentList[viewPager.currentItem].getSendData())
+                    }
                 } else {
                     prepareForScan()
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,9 @@
     <string name="import_dialog">Import File</string>
     <string name="import_dialog_message">Do you want to import</string>
     <string name="sending_data">Sending Data.</string>
+    <string name="empty_edittext">Please enter some text to be displayed.</string>
+    <string name="no_drawable">No bitmap selected. Sending default bitmap.</string>
+    <string name="no_configuration">No saved configuration selected. Sending default bitmap.</string>
     <string name="text_draw_fragment">Text/Drawable</string>
     <string name="saved_fragment">Saved List</string>
 </resources>


### PR DESCRIPTION
Fixes #203 

Changes: 
- If edit text is empty and the user presses the fab to send, a toast is shown and no action is taken.
- If no drawable is selected and the user presses the fab to send, a toast is displayed and a default bitmap is sent.
- If no saved configuration is selected and the user presses the fab to send, a toast is displayed and a default bitmap is sent.

Screenshots for the change:

![Screenshot_20190430-145811](https://user-images.githubusercontent.com/41234408/56952893-ed0f2e80-6b58-11e9-8c2d-8c55ac4f7626.png)
