### PR TITLE
fix: App crash on installing

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/util/StorageUtils.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/util/StorageUtils.kt
@@ -38,7 +38,7 @@ object StorageUtils {
         checkDirectory()
         val list = mutableListOf<ConfigInfo>()
 
-        val files = File(EXTERNAL_STORAGE_DIRECTORY).listFiles()
+        val files = File(EXTERNAL_STORAGE_DIRECTORY).listFiles() ?: return list
         for (i in files.indices) {
             if (getFileExtension(files[i].name) == BADGE_EXTENSION) {
                 val json = files[i].readText()


### PR DESCRIPTION
Fixes: #253

It crashes due to NullPointerException from files variable