### PR TITLE
fix: retain items on rotate

### DIFF
--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/main_saved/MainSavedFragment.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/main_saved/MainSavedFragment.kt
@@ -47,8 +47,11 @@ class MainSavedFragment : BaseFragment() {
     }
 
     override fun inject() {
-        viewModel = ViewModelProviders.of(this, InjectorUtils.provideFilesViewModelFactory())
-            .get(AppViewModel::class.java)
+        val currentActivity = activity
+        if (currentActivity != null)
+            viewModel = ViewModelProviders
+                .of(currentActivity, InjectorUtils.provideFilesViewModelFactory())
+                .get(AppViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/main_text/MainTextDrawableFragment.kt
+++ b/app/src/main/java/com/nilhcem/blenamebadge/ui/fragments/main_text/MainTextDrawableFragment.kt
@@ -69,8 +69,10 @@ class MainTextDrawableFragment : BaseFragment() {
     }
 
     override fun inject() {
-        viewModel = ViewModelProviders
-                .of(this, InjectorUtils.provideMainTextDrawableViewModelFactory())
+        val currentActivity = activity
+        if (currentActivity != null)
+            viewModel = ViewModelProviders
+                .of(currentActivity, InjectorUtils.provideMainTextDrawableViewModelFactory())
                 .get(MainTextDrawableViewModel::class.java)
     }
 


### PR DESCRIPTION
Fixes #280 

Changes:
- viewholder is attached to the activity instead of fragments

Screenshots for the change:
![](https://camo.githubusercontent.com/5a305747982dd58caadef81a50ba075a1417f193/68747470733a2f2f692e696d6775722e636f6d2f6c4f796579655a2e676966)