### PR TITLE
feat: App shortcuts added

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,10 @@
 
                 <data android:mimeType="text/*" />
             </intent-filter>
+
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/org/fossasia/badgemagic/ui/drawer/DrawerActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/drawer/DrawerActivity.kt
@@ -68,6 +68,16 @@ class DrawerActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelec
         setupDrawerAndToolbar()
 
         prepareForScan()
+
+        if (intent.action == "org.fossasia.badgemagic.savedBadges.shortcut") {
+            switchFragment(MainSavedFragment.newInstance())
+            showMenu?.setGroupVisible(R.id.saved_group, true)
+        }
+
+        if (intent.action == "org.fossasia.badgemagic.createBadge.shortcut") {
+            switchFragment(MainTextDrawableFragment.newInstance())
+            showMenu?.setGroupVisible(R.id.saved_group, false)
+        }
     }
 
     private fun setupDrawerAndToolbar() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,5 +85,8 @@
     <string name="licences_copy">Copyright 2013 Philip Schiffer</string>
     <string name="empty_saved_section">Looks like there are no saved badges yet</string>
     <string name="empty_saved_section_title">No Saved Badges !</string>
+    <string name="create">Create Badge</string>
+    <string name="saved">Saved Badges</string>
+    <string name="disabled">App shortcuts are not supported on your device.</string>
 
 </resources>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,29 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="createBadge"
+        android:enabled="true"
+        android:icon="@drawable/ic_menu_create"
+        android:shortcutShortLabel="@string/create"
+        android:shortcutLongLabel="@string/create"
+        android:shortcutDisabledMessage="@string/disabled">
+        <intent
+            android:action="org.fossasia.badgemagic.createBadge.shortcut"
+            android:targetPackage="org.fossasia.badgemagic"
+            android:targetClass="org.fossasia.badgemagic.ui.drawer.DrawerActivity" />
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="saveBadge"
+        android:enabled="true"
+        android:icon="@drawable/ic_menu_save"
+        android:shortcutShortLabel="@string/saved"
+        android:shortcutLongLabel="@string/saved"
+        android:shortcutDisabledMessage="@string/disabled">
+        <intent
+            android:action="org.fossasia.badgemagic.savedBadges.shortcut"
+            android:targetPackage="org.fossasia.badgemagic"
+            android:targetClass="org.fossasia.badgemagic.ui.drawer.DrawerActivity" />
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
Fixes #308 

Changes: App shortcuts have been added to directly access saved badges or create badges modes.

Screenshots for the change:

![Screenshot_20190519-165309](https://user-images.githubusercontent.com/41234408/57981604-15eb5b00-7a57-11e9-9967-5138dedfddec.png)
