### PR TITLE
fix: memory leak due to EditableInputConnection

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/custom/NoInputConnEditText.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/custom/NoInputConnEditText.kt
@@ -1,0 +1,41 @@
+package org.fossasia.badgemagic.ui.custom
+
+import android.content.Context
+import android.text.TextUtils
+import android.text.Editable
+import android.text.method.ArrowKeyMovementMethod
+import android.text.method.MovementMethod
+import android.util.AttributeSet
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
+import androidx.appcompat.widget.AppCompatTextView
+
+class NoInputConnEditText @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = android.R.attr.editTextStyle) : AppCompatTextView(context, attrs, defStyle) {
+
+    override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
+        return null
+    }
+
+    override fun getDefaultEditable(): Boolean {
+        return true
+    }
+
+    override fun getDefaultMovementMethod(): MovementMethod {
+        return ArrowKeyMovementMethod.getInstance()
+    }
+
+    override fun getText(): Editable {
+        return super.getText() as Editable
+    }
+
+    override fun setText(text: CharSequence, type: BufferType) {
+        super.setText(text, BufferType.EDITABLE)
+    }
+
+    override fun setEllipsize(ellipsis: TextUtils.TruncateAt) {
+        if (ellipsis == TextUtils.TruncateAt.MARQUEE) {
+            throw IllegalArgumentException("EditText cannot use the ellipsize mode " + "TextUtils.TruncateAt.MARQUEE")
+        }
+        super.setEllipsize(ellipsis)
+    }
+}

--- a/app/src/main/res/layout-land/fragment_main_text.xml
+++ b/app/src/main/res/layout-land/fragment_main_text.xml
@@ -66,14 +66,12 @@
                             android:layout_height="wrap_content"
                             android:orientation="vertical">
 
-
-                            <EditText
+                            <org.fossasia.badgemagic.ui.custom.NoInputConnEditText
                                 android:id="@+id/text_to_send"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:layout_marginTop="@dimen/spacing_small"
-                                android:hint="@string/enter_text"
-                                android:inputType="text" />
+                                android:hint="@string/enter_text" />
 
                         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_main_text.xml
+++ b/app/src/main/res/layout/fragment_main_text.xml
@@ -53,13 +53,12 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                    <EditText
+                    <org.fossasia.badgemagic.ui.custom.NoInputConnEditText
                         android:id="@+id/text_to_send"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/spacing_small"
-                        android:hint="@string/enter_text"
-                        android:inputType="text" />
+                        android:hint="@string/enter_text" />
 
                 </LinearLayout>
 


### PR DESCRIPTION
Fixes #316

Changes: 
- fixed memory leak by disabling the InputConnection

Additional Context:
https://stackoverflow.com/questions/14069501/edittext-causing-memory-leak
