### PR TITLE
chore: runtime JAR files in the classpath should have the same version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,15 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    configurations.all {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            def requested = details.requested
+            if (requested.group == 'org.jetbrains.kotlin' && requested.name == 'kotlin-reflect') {
+                details.useVersion versions.kotlin_version
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled true


### PR DESCRIPTION
Fixes #335 

Changes:
- we set the reflect version manually from the versions file