### PR TITLE
feat: Bluetooth permission is asked when user presses the transfer button

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
@@ -3,7 +3,6 @@ package org.fossasia.badgemagic.ui
 import android.Manifest
 import android.app.Activity
 import android.app.AlertDialog
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.DialogInterface
@@ -163,31 +162,13 @@ class DrawerActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelec
             }
             REQUEST_ENABLE_BT -> {
                 this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-                if (resultCode == Activity.RESULT_CANCELED) {
-                    showAlertDialog(true)
-                    return
-                } else if (resultCode == Activity.RESULT_OK) {
+                if (resultCode == Activity.RESULT_OK) {
                     prepareForScan()
                     return
                 }
             }
         }
         super.onActivityResult(requestCode, resultCode, data)
-    }
-
-    private fun showAlertDialog(bluetoothDialog: Boolean) {
-        val dialogMessage = if (bluetoothDialog) getString(R.string.enable_bluetooth) else getString(R.string.grant_required_permission)
-        val builder = AlertDialog.Builder(this)
-        builder.setIcon(resources.getDrawable(R.drawable.ic_caution))
-        builder.setTitle(getString(R.string.permission_required))
-        builder.setMessage(dialogMessage)
-        builder.setPositiveButton("OK") { _, _ ->
-            prepareForScan()
-        }
-        builder.setNegativeButton("CANCEL") { _, _ ->
-            Toast.makeText(this, R.string.enable_bluetooth, Toast.LENGTH_SHORT).show()
-        }
-        builder.create().show()
     }
 
     private fun switchFragment(fragment: BaseFragment) {
@@ -199,7 +180,6 @@ class DrawerActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelec
     private fun checkManifestPermission() {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED &&
             ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-            ensureBluetoothEnabled()
             Timber.i { "Coarse permission granted" }
         } else {
             ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.WRITE_EXTERNAL_STORAGE), REQUEST_PERMISSION_CODE)
@@ -211,9 +191,6 @@ class DrawerActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelec
             REQUEST_PERMISSION_CODE -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
                     Timber.d { "Required Permission Accepted" }
-                    ensureBluetoothEnabled()
-                } else {
-                    showAlertDialog(false)
                 }
             }
             else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)
@@ -222,17 +199,6 @@ class DrawerActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelec
 
     private fun isBleSupported(): Boolean {
         return packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)
-    }
-
-    private fun ensureBluetoothEnabled() {
-        // Ensures Bluetooth is enabled on the device
-        val btManager = getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-        val btAdapter = btManager.adapter
-        if (!btAdapter.isEnabled) {
-            val enableBtIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
-            this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
-            startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT)
-        }
     }
 
     private fun disableBluetooth() {

--- a/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
@@ -3,6 +3,8 @@ package org.fossasia.badgemagic.ui.fragments
 import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.Context
 import android.content.DialogInterface
 import android.content.res.Configuration
 import android.graphics.Color
@@ -20,6 +22,7 @@ import android.widget.EditText
 import android.widget.TextView
 import android.widget.LinearLayout
 import android.widget.Toast
+import androidx.core.content.ContextCompat.getSystemService
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.tabs.TabLayout
@@ -130,9 +133,33 @@ class TextArtFragment : BaseFragment() {
 
                     SendingUtils.sendMessage(requireContext(), getSendData())
                 } else
-                    Toast.makeText(requireContext(), getString(R.string.enable_bluetooth), Toast.LENGTH_LONG).show()
+                    showAlertDialog()
             } else
                 Toast.makeText(requireContext(), getString(R.string.empty_text_to_send), Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun showAlertDialog() {
+        val dialogMessage = getString(R.string.enable_bluetooth)
+        val builder = AlertDialog.Builder(context)
+        builder.setIcon(resources.getDrawable(R.drawable.ic_caution))
+        builder.setTitle(getString(R.string.permission_required))
+        builder.setMessage(dialogMessage)
+        builder.setPositiveButton("OK") { _, _ ->
+            turnOnBluetooth()
+            Toast.makeText(context, R.string.bluetooth_enabled, Toast.LENGTH_SHORT).show()
+        }
+        builder.setNegativeButton("CANCEL") { _, _ ->
+            Toast.makeText(context, R.string.enable_bluetooth, Toast.LENGTH_SHORT).show()
+        }
+        builder.create().show()
+    }
+
+    private fun turnOnBluetooth() {
+        val btManager = requireContext().getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+        val btAdapter = btManager.adapter
+        if (btAdapter.disable()) {
+            btAdapter.enable()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,5 +86,6 @@
     <string name="saved">Saved Badges</string>
     <string name="disabled">App shortcuts are not supported on your device.</string>
     <string name="empty_text_to_send">Please Enter Something to Send</string>
+    <string name="bluetooth_enabled">Bluetooth has been turned on.</string>
 
 </resources>


### PR DESCRIPTION
Fixes #351

Changes: Bluetooth permission is now asked only when the user presses the transfer button and not on opening the app.
