### PR TITLE
chore: Replaced context with requireContext

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
@@ -141,7 +141,7 @@ class TextArtFragment : BaseFragment() {
 
     private fun showAlertDialog() {
         val dialogMessage = getString(R.string.enable_bluetooth)
-        val builder = AlertDialog.Builder(context)
+        val builder = AlertDialog.Builder(requireContext())
         builder.setIcon(resources.getDrawable(R.drawable.ic_caution))
         builder.setTitle(getString(R.string.permission_required))
         builder.setMessage(dialogMessage)


### PR DESCRIPTION
Changes: Replaced `context` with `requireContext()` as it is better for use in fragments. `context` might return a null value, but `requireContext()` will never return a null value.
