### PR TITLE
fix: badge seems to cut off on devices with 19.5:9 ratio

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/custom/PreviewBadge.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/custom/PreviewBadge.kt
@@ -93,7 +93,7 @@ class PreviewBadge : View {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
 
         val ratioHeight = 1
-        val ratioWidth = 3.45
+        val ratioWidth = 3
 
         val originalWidth = MeasureSpec.getSize(widthMeasureSpec)
         val calculatedHeight = originalWidth * ratioHeight / ratioWidth


### PR DESCRIPTION
Fixes #394