### PR TITLE
feat: Added toast when a badge is saved

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
@@ -445,6 +445,7 @@ class TextArtFragment : BaseFragment() {
                         showFileOverrideDialog(fileTitle.toString(), configToJSON())
                     } else {
                         saveFile(fileTitle.toString(), configToJSON())
+                        Toast.makeText(context, R.string.saved_badge, Toast.LENGTH_SHORT).show()
                     }
                 }
             }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -22,6 +22,7 @@
     <string name="enter_text">输入文字</string>
     <string name="image_bitmap_description">位图图像</string>
     <string name="save_button">保存</string>
+    <string name="saved_badge">Saved Badge</string>
     <string name="save_hint">文件名</string>
     <string name="validation_save_dialog">继续之前输入文件名</string>
     <string name="save_dialog_title">保存徽章</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="save_hint">File Name</string>
     <string name="validation_save_dialog">Enter file name before continuing</string>
     <string name="save_dialog_title">Save Badge</string>
+    <string name="saved_badge">Saved Badge</string>
     <string name="saved_configurations">Saved Badges</string>
     <string name="saveactivity_operation_title">Perform Operation</string>
     <string name="delete">Delete</string>


### PR DESCRIPTION
Fixes #411 

Changes: A toast notification is shown when a badge is saved.

Screenshots for the change:

![screencap](https://user-images.githubusercontent.com/41234408/60115427-8773a300-9793-11e9-8845-9f67fc67af47.png)
