### PR TITLE
fix: Prevented bluetooth form closing automatically when drawer activity is destroyed.

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
@@ -3,8 +3,6 @@ package org.fossasia.badgemagic.ui
 import android.Manifest
 import android.app.Activity
 import android.app.AlertDialog
-import android.bluetooth.BluetoothManager
-import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.ActivityInfo
@@ -249,14 +247,6 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
         return packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)
     }
 
-    private fun disableBluetooth() {
-        val btManager = getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-        val btAdapter = btManager.adapter
-        if (btAdapter.isEnabled) {
-            btAdapter.disable()
-        }
-    }
-
     private fun saveImportFile(uri: Uri?) {
         if (StorageUtils.copyFileToDirectory(this, uri)) {
             Toast.makeText(this, R.string.success_import_json, Toast.LENGTH_SHORT).show()
@@ -295,11 +285,6 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
             }
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onDestroy() {
-        disableBluetooth()
-        super.onDestroy()
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
Fixes #413 

Changes: Bluetooth will not be turned off automatically when the drawer activity is destroyed.

