### PR TITLE
Fixes #479 Edit Badge Screen / Edit Clipart Screen

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/EditBadgeActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/EditBadgeActivity.kt
@@ -2,6 +2,8 @@ package org.fossasia.badgemagic.ui
 
 import android.os.AsyncTask
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -49,6 +51,20 @@ class EditBadgeActivity : AppCompatActivity() {
                 draw_layout.resetCheckListWithDummyData()
             }
         })
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.open_folder, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.open_Folder -> {
+                finish()
+            }
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     companion object {

--- a/app/src/main/java/org/fossasia/badgemagic/ui/EditClipartActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/EditClipartActivity.kt
@@ -1,6 +1,8 @@
 package org.fossasia.badgemagic.ui
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -44,5 +46,18 @@ class EditClipartActivity : AppCompatActivity() {
                 draw_layout.resetCheckListWithDummyData()
             }
         })
+    }
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.open_folder, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.open_Folder -> {
+                finish()
+            }
+        }
+        return super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/res/drawable/ic_folder_open_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_folder_open_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,6h-8l-2,-2L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,8c0,-1.1 -0.9,-2 -2,-2zM20,18L4,18L4,8h16v10z"/>
+</vector>

--- a/app/src/main/res/menu/open_folder.xml
+++ b/app/src/main/res/menu/open_folder.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:title="Open Folder"
+        android:id="@+id/open_Folder"
+        android:icon="@drawable/ic_folder_open_black_24dp"
+        app:showAsAction="always"
+        />
+
+</menu>


### PR DESCRIPTION
Fixes #479 Edit Badge Screen / Edit Clipart Screen
Add an "Open Folder" icon to the edit badge screen and edit clipart screen on the top right of the screen on the menu bar. The icon should open "Saved Badges" and "Saved Cliparts" respectively.
