### PR TITLE
feat: added shortcut to open saved activities from edit activities

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
@@ -63,17 +63,23 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
 
         prepareForScan()
 
+        handleIfReceiveIntent()
+    }
+
+    private fun handleIfReceiveIntent() {
         val bundle = intent.extras
         if (bundle?.getString("clipart").equals("clipart")) {
             val clipart = SavedClipartFragment()
             supportFragmentManager.beginTransaction()
                     .replace(R.id.frag_container, clipart)
                     .commit()
+            nav_view.setCheckedItem(R.id.saved_cliparts)
         } else if (bundle?.getString("badge").equals("badge")) {
             val badge = SavedBadgesFragment()
             supportFragmentManager.beginTransaction()
                     .replace(R.id.frag_container, badge)
                     .commit()
+            nav_view.setCheckedItem(R.id.saved_badges)
         }
     }
 

--- a/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
@@ -62,13 +62,26 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
         setupDrawerAndToolbar()
 
         prepareForScan()
+
+        val bundle = intent.extras
+        if (bundle?.getString("clipart").equals("clipart")) {
+            val clipart = SavedClipartFragment()
+            supportFragmentManager.beginTransaction()
+                    .replace(R.id.frag_container, clipart)
+                    .commit()
+        } else if (bundle?.getString("badge").equals("badge")) {
+            val badge = SavedBadgesFragment()
+            supportFragmentManager.beginTransaction()
+                    .replace(R.id.frag_container, badge)
+                    .commit()
+        }
     }
 
     private fun setupDrawerAndToolbar() {
         setSupportActionBar(toolbar)
 
         val toggle = ActionBarDrawerToggle(
-            this, drawer_layout, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close)
+                this, drawer_layout, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close)
         drawer_layout.addDrawerListener(toggle)
         toggle.syncState()
 
@@ -179,19 +192,19 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
 
     private fun showImportDialog(uri: Uri?) {
         AlertDialog.Builder(this)
-            .setTitle(getString(R.string.import_dialog))
-            .setMessage("${getString(R.string.import_dialog_message)} ${StorageUtils.getFileName(this, uri
-                ?: Uri.EMPTY)}")
-            .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
-                if (!StorageUtils.checkIfFilePresent(this, uri)) {
-                    saveImportFile(uri)
-                } else
-                    showOverrideDialog(uri)
-            }
-            .setNegativeButton(android.R.string.cancel) { dialog, _ ->
-                dialog.cancel()
-            }
-            .show()
+                .setTitle(getString(R.string.import_dialog))
+                .setMessage("${getString(R.string.import_dialog_message)} ${StorageUtils.getFileName(this, uri
+                        ?: Uri.EMPTY)}")
+                .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
+                    if (!StorageUtils.checkIfFilePresent(this, uri)) {
+                        saveImportFile(uri)
+                    } else
+                        showOverrideDialog(uri)
+                }
+                .setNegativeButton(android.R.string.cancel) { dialog, _ ->
+                    dialog.cancel()
+                }
+                .show()
     }
 
     override fun onPause() {
@@ -219,13 +232,13 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
 
     private fun switchFragment(fragment: BaseFragment) {
         supportFragmentManager.beginTransaction()
-            .replace(R.id.frag_container, fragment)
-            .commit()
+                .replace(R.id.frag_container, fragment)
+                .commit()
     }
 
     private fun checkManifestPermission() {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED &&
-            ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+                ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
             Timber.i { "Coarse permission granted" }
         } else {
             ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.WRITE_EXTERNAL_STORAGE), REQUEST_PERMISSION_CODE)
@@ -256,15 +269,15 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
 
     private fun showOverrideDialog(uri: Uri?) {
         AlertDialog.Builder(this)
-            .setTitle(getString(R.string.save_dialog_already_present))
-            .setMessage(getString(R.string.save_dialog_already_present_override))
-            .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
-                saveImportFile(uri)
-            }
-            .setNegativeButton(android.R.string.cancel) { dialog, _ ->
-                dialog.cancel()
-            }
-            .show()
+                .setTitle(getString(R.string.save_dialog_already_present))
+                .setMessage(getString(R.string.save_dialog_already_present_override))
+                .setPositiveButton(android.R.string.ok) { _: DialogInterface, _: Int ->
+                    saveImportFile(uri)
+                }
+                .setNegativeButton(android.R.string.cancel) { dialog, _ ->
+                    dialog.cancel()
+                }
+                .show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/java/org/fossasia/badgemagic/ui/EditBadgeActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/EditBadgeActivity.kt
@@ -1,7 +1,10 @@
 package org.fossasia.badgemagic.ui
 
+import android.content.Intent
 import android.os.AsyncTask
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -35,8 +38,8 @@ class EditBadgeActivity : AppCompatActivity() {
             if (it) {
                 val badgeConfig = SendingUtils.getBadgeFromJSON(viewModel.drawingJSON.get() ?: "{}")
                 badgeConfig?.hexStrings = Converters.convertBitmapToLEDHex(
-                    Converters.convertStringsToLEDHex(draw_layout.getCheckedList()),
-                    false
+                        Converters.convertStringsToLEDHex(draw_layout.getCheckedList()),
+                        false
                 )
                 badgeConfig?.let { config -> StoreAsync(fileName, config, viewModel).execute() }
                 Toast.makeText(this, R.string.saved_edited_badge, Toast.LENGTH_LONG).show()
@@ -49,6 +52,22 @@ class EditBadgeActivity : AppCompatActivity() {
                 draw_layout.resetCheckListWithDummyData()
             }
         })
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.open_folder, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.open_Folder -> {
+                val intent = Intent(this, DrawerActivity::class.java)
+                intent.putExtra("badge", "badge")
+                startActivity(intent)
+            }
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     companion object {

--- a/app/src/main/java/org/fossasia/badgemagic/ui/EditBadgeActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/EditBadgeActivity.kt
@@ -64,6 +64,7 @@ class EditBadgeActivity : AppCompatActivity() {
             R.id.open_Folder -> {
                 val intent = Intent(this, DrawerActivity::class.java)
                 intent.putExtra("badge", "badge")
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 startActivity(intent)
             }
         }

--- a/app/src/main/java/org/fossasia/badgemagic/ui/EditClipartActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/EditClipartActivity.kt
@@ -1,6 +1,9 @@
 package org.fossasia.badgemagic.ui
 
+import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -44,5 +47,21 @@ class EditClipartActivity : AppCompatActivity() {
                 draw_layout.resetCheckListWithDummyData()
             }
         })
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.open_folder, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.open_Folder -> {
+                val intent = Intent(this, DrawerActivity::class.java)
+                intent.putExtra("clipart", "clipart")
+                startActivity(intent)
+            }
+        }
+        return super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/org/fossasia/badgemagic/ui/EditClipartActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/EditClipartActivity.kt
@@ -59,6 +59,7 @@ class EditClipartActivity : AppCompatActivity() {
             R.id.open_Folder -> {
                 val intent = Intent(this, DrawerActivity::class.java)
                 intent.putExtra("clipart", "clipart")
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 startActivity(intent)
             }
         }

--- a/app/src/main/res/drawable/ic_folder_open_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_folder_open_black_24dp.xml
@@ -1,6 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
         android:width="24dp"
         android:height="24dp"
+        android:tint="#FFFFFF"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path

--- a/app/src/main/res/drawable/ic_folder_open_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_folder_open_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,6h-8l-2,-2L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,8c0,-1.1 -0.9,-2 -2,-2zM20,18L4,18L4,8h16v10z"/>
+</vector>

--- a/app/src/main/res/menu/open_folder.xml
+++ b/app/src/main/res/menu/open_folder.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:title="Open Folder"
+        android:id="@+id/open_Folder"
+        android:icon="@drawable/ic_folder_open_black_24dp"
+        app:showAsAction="always"
+        />
+
+</menu>


### PR DESCRIPTION
Fixes #479 Edit Badge Screen / Edit Clipart Screen

Add an "Open Folder" icon to the edit badge/edit clipart screen on the top right of the screen on the menu bar. The icon should open "Saved Badges" / "Saved Cliparts".

EditBadgeScreen:-

![Screenshot_2019-11-28-00-13-02-038_org fossasia badgemagic](https://user-images.githubusercontent.com/44283521/69751109-649b4f80-1174-11ea-935f-47fd254c8400.png)

EditClipartScreen:-

![Screenshot_2019-11-28-00-13-29-569_org fossasia badgemagic](https://user-images.githubusercontent.com/44283521/69751155-7ed52d80-1174-11ea-91fe-bad5c2176a19.png)
