### PR TITLE
fix: Resolve delete cliparts issue

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/adapter/SavedClipartsAdapter.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/adapter/SavedClipartsAdapter.kt
@@ -40,6 +40,7 @@ class SavedClipartsAdapter(
 
     fun setList(list: List<SavedClipart>) {
         clipartList = list
+        viewModel.setList(list)
         notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/org/fossasia/badgemagic/viewmodels/SavedClipartViewModel.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/viewmodels/SavedClipartViewModel.kt
@@ -17,4 +17,8 @@ class SavedClipartViewModel(
     fun deleteClipart(position: Int) {
         clipArtService.deleteClipart(cliparts[position].fileName)
     }
+
+    fun setList(list: List<SavedClipart>) {
+        cliparts = list
+    }
 }


### PR DESCRIPTION
Fixes #528 

Changes: The clipart list in viewmodel was not populated. So, I created another method in the viewmodel that populates the list from the adapter. Now, the clipart is getting deleted without any crash.