### PR TITLE
fix: Resolve intermediate clipart delete issue

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
@@ -230,8 +230,7 @@ class TextArtFragment : BaseFragment() {
                     counter++
                     if (startPos == -1)
                         startPos = i
-                }
-                else if (s?.get(i) == DRAWABLE_END)
+                } else if (s?.get(i) == DRAWABLE_END)
                     counter--
 
                 if (counter == 0) {

--- a/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
@@ -213,18 +213,36 @@ class TextArtFragment : BaseFragment() {
     }
 
     private val textChangedListener = object : TextWatcher {
+        var startPos = -1
+        var endPos = -1
         override fun afterTextChanged(s: Editable?) {
-            if (s != null) {
-                val drawableStartIndex = s.lastIndexOf(DRAWABLE_START)
-                if (drawableStartIndex > s.lastIndexOf(DRAWABLE_END))
-                    s.delete(drawableStartIndex, s.length)
-            }
+            if (startPos != -1)
+                s?.delete(startPos, endPos)
+            setPreview()
         }
 
         override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-            viewModel.text = s.toString()
-            setPreview()
+            var counter = 0
+            endPos = start
+            for (i in s.toString().indices) {
+                if (s?.get(i) == DRAWABLE_START) {
+                    counter++
+                    if (startPos == -1)
+                        startPos = i
+                }
+                else if (s?.get(i) == DRAWABLE_END)
+                    counter--
+
+                if (counter == 0) {
+                    startPos = -1
+                }
+            }
+
+            if (startPos != -1)
+                viewModel.text = s.toString().removeRange(startPos, start)
+            else
+                viewModel.text = s.toString()
         }
     }
 


### PR DESCRIPTION
Fixes #527 

Changes: The issue was due to not slicing the string in a proper way. In the onTextChanged method of the listener, I have changed the implementation to update the string without the text of the deleted clipart and instead of calling the setPreview method in the onTextChanged, it's being called in afterTextChanged method, which makes more sense.
