### PR TITLE
fix: uneven clipart listing

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/database/ClipArtService.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/database/ClipArtService.kt
@@ -12,7 +12,7 @@ import org.koin.core.inject
 
 class ClipArtService : KoinComponent {
     private val clipArts = MutableLiveData<SparseArray<Drawable>>()
-    private val storageClipArts = MutableLiveData<HashMap<String, Drawable?>>()
+    private val storageClipArts = MutableLiveData<MutableMap<String, Drawable?>>()
     private val resourceHelper: Resource by inject()
     private val storageUtils: StorageUtils by inject()
 
@@ -63,7 +63,7 @@ class ClipArtService : KoinComponent {
 
     fun getClipArts(): LiveData<SparseArray<Drawable>> = clipArts
 
-    fun getClipsFromStorage(): LiveData<HashMap<String, Drawable?>> = storageClipArts
+    fun getClipsFromStorage(): LiveData<MutableMap<String, Drawable?>> = storageClipArts
 
     fun deleteClipart(fileName: String) {
         storageUtils.deleteClipart(fileName)

--- a/app/src/main/java/org/fossasia/badgemagic/util/StorageUtils.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/util/StorageUtils.kt
@@ -180,11 +180,12 @@ class StorageUtils(val context: Context) {
         return true
     }
 
-    fun getAllClips(): HashMap<String, Drawable?> {
+    fun getAllClips(): MutableMap<String, Drawable?> {
         checkDirectory()
-        val list = HashMap<String, Drawable?>()
+        val list = mutableMapOf<String, Drawable?>()
 
         val files = File(externalClipartDir).listFiles() ?: return list
+        files.sortWith(Comparator<File> { a, b -> (b.lastModified() - a.lastModified()).toInt() })
         for (i in files.indices) {
             if (getFileExtension(files[i].name) == clipExt) {
                 list[files[i].name] = Drawable.createFromPath(files[i].absolutePath)


### PR DESCRIPTION
Fixes #577 
if I insert clipart in order 1 2 3 4 then this is how it displays (according to date of creation or modification)
also when a user updates or edits it then display according to date of last modification.
Screenshots for the change:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/44283521/71490642-dc32cc00-2851-11ea-8c6d-8af4745090ce.gif)
