### PR TITLE
fix: Resolve drawer selection issue in draw clipart fragment

### DIFF
--- a/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
+++ b/app/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
@@ -168,7 +168,7 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
         nav_view.setNavigationItemSelectedListener(this)
         if (!viewModel.swappingOrientation)
             when (intent.action) {
-                Intent.ACTION_MAIN, "org.fossasia.badgemagic.createBadge.shortcut" -> {
+                "org.fossasia.badgemagic.createBadge.shortcut" -> {
                     switchFragment(TextArtFragment.newInstance())
                     showMenu?.setGroupVisible(R.id.saved_group, false)
                     nav_view.setCheckedItem(R.id.create)


### PR DESCRIPTION
Fixes #594 

Changes: The issue was with the intent action condition. It was earlier defined that if the action is MAIN then open TextArtFragment and every action is by default is MAIN so I just removed that condition and now it's working perfectly.
