### PR TITLE
feat: about us selection in drawer

### DIFF
--- a/android/src/main/res/menu/drawer_items.xml
+++ b/android/src/main/res/menu/drawer_items.xml
@@ -24,6 +24,10 @@
             android:id="@+id/settings"
             android:icon="@drawable/ic_menu_settings"
             android:title="@string/drawer_settings" />
+        <item
+            android:id="@+id/about"
+            android:icon="@drawable/ic_menu_about"
+            android:title="@string/drawer_about_us" />
     </group>
 
     <item android:title="@string/drawer_other">
@@ -36,10 +40,6 @@
                 android:id="@+id/share_app_details"
                 android:icon="@drawable/ic_share"
                 android:title="@string/drawer_share_app" />
-            <item
-                android:id="@+id/about"
-                android:icon="@drawable/ic_menu_about"
-                android:title="@string/drawer_about_us" />
             <item
                 android:id="@+id/feedback"
                 android:icon="@drawable/ic_menu_bug"


### PR DESCRIPTION
Fixes #614  

Changes: 
Removed about us from unchecked section where the item checked state was not imp (eg. Share, buy )

Screenshots for the change:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/18233626/71768454-0401ee00-2f3c-11ea-8bf0-3e14ecb623a5.gif)
