### PR TITLE
fix: Semantic changes for delete confirmation message

### DIFF
--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -98,6 +98,6 @@
     <string name="share_using">分享使用</string>
     <string name="badge_delete_warning">" 您确定要删除此徽章吗？"</string>
     <string name="clipart_delete_warning">" 您确定要删除此剪贴画吗？"</string>
-    <string name="delete_badge_confirm">" 成功删除徽章"</string>
-    <string name="delete_clipart_confirm">" 成功删除剪贴画"</string>
+    <string name="delete_badge_confirm">徽章已成功刪除</string>
+    <string name="delete_clipart_confirm">剪貼畫已成功刪除</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -15,8 +15,8 @@
     <string name="enable_bluetooth">You must turn Bluetooth on to use send feature</string>
     <string name="badge_delete_warning">Are you sure want to delete this badge?</string>
     <string name="clipart_delete_warning">Are you sure want to delete this clipart?</string>
-    <string name="delete_badge_confirm">Delete Badge Successfully</string>
-    <string name="delete_clipart_confirm">Delete Clipart Successfully</string>
+    <string name="delete_badge_confirm">Badge deleted Successfully</string>
+    <string name="delete_clipart_confirm">Clipart deleted Successfully</string>
 
     <string name="flash">Flash</string>
     <string name="marquee">Marquee</string>


### PR DESCRIPTION
Fixes #[619]

Changes: Corrected delete messages for both languages, similar to that of saved badge message.


