### PR TITLE
chore: added License Badge to the Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img height="200px" src="./docs/images/app_icon.png" align="right" />
 
 # Badge Magic
-[![Build Status](https://travis-ci.org/fossasia/badge-magic-android.svg?branch=development)](https://travis-ci.org/fossasia/badge-magic-android) [![Join the chat at https://gitter.im/fossasia/badge-magic](https://badges.gitter.im/fossasia/badge-magic.svg)](https://gitter.im/fossasia/badge-magic?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/fossasia/badge-magic-android.svg?branch=development)](https://travis-ci.org/fossasia/badge-magic-android) [![Join the chat at https://gitter.im/fossasia/badge-magic](https://badges.gitter.im/fossasia/badge-magic.svg)](https://gitter.im/fossasia/badge-magic?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) ![Github](https://img.shields.io/github/license/fossasia/badge-magic-android?logo=github)
 
 **Python Library to program via desktop https://github.com/fossasia/led-name-badge-ls32
 


### PR DESCRIPTION
user gets the info of license at first glance
also added a github logo to that badge

Fixes #[Add issue number here. If you solve the issue entirely, else please change the message e.g. "First steps or Part of for issues #IssueNumber]

Changes: [Add Licence badge ]
Screenshots for the change:
https://github.com/fossasia/badge-magic-android/compare/development...atharwa-24:development#diff-04c6e90faac2675aa89e2176d2eec7d8
![changes](https://user-images.githubusercontent.com/54115798/89555177-5afed700-d82d-11ea-8f03-8819b0094da2.PNG)

