### PR TITLE
Removed Background Location Permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
 
     <uses-feature android:name="android.hardware.location.gps" />
 


### PR DESCRIPTION
Fixes #748 

Changes: Removed Background Location Permission from Android Manifest for the proposed issue #748.
