### PR TITLE
Removed Background Location Access

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
 
     <uses-feature android:name="android.hardware.location.gps" />
 


### PR DESCRIPTION
Fixes #748

Changes: 
Removed Background Location Access from manifest file

Screenshots for the change:
Not Applicable

APK: [Download Here](https://appsenjoy.com/xhnpi)

