### PR TITLE
fix: squashed bullet list in subject examples

### DIFF
--- a/docs/commitStyle.md
+++ b/docs/commitStyle.md
@@ -35,6 +35,7 @@ For example:
 - feat: Update UI of AbcActivity
 - fix: Remove deprecated methods
 - refactor: API endpoints and JSON assets
+
 instead of writing the following: 
 - Fixed bug with Y
 - Changing behaviour of X


### PR DESCRIPTION
Examples were divided into two logical bullet lists, good examples followed by bad examples. An ignored newline in raw markdown means the lists were not separated as they should be.

Hopefully this simple extra newline fixes it.