### PR TITLE
fix: Build errors due to old kotlin and gradle versions

### DIFF
--- a/BadgeMagicModule/build.gradle.kts
+++ b/BadgeMagicModule/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 }
 
-val kt_serial = "0.14.0"
+val kt_serial = "1.6.2"
 val klockVersion = "1.8.6"
 
 kotlin {
@@ -24,17 +24,17 @@ kotlin {
 
     sourceSets["commonMain"].dependencies {
         implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
-        implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$kt_serial")
+        implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kt_serial")
         implementation("com.soywiz.korlibs.klock:klock:$klockVersion")
     }
 
     sourceSets["androidMain"].dependencies {
         implementation("org.jetbrains.kotlin:kotlin-stdlib")
-        implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kt_serial")
+        implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kt_serial")
     }
 
     sourceSets["iosMain"].dependencies {
-        implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$kt_serial")
+        implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kt_serial")
     }
 }
 

--- a/BadgeMagicModule/src/commonMain/kotlin/org/fossasia/badgemagic/helpers/JSONHelper.kt
+++ b/BadgeMagicModule/src/commonMain/kotlin/org/fossasia/badgemagic/helpers/JSONHelper.kt
@@ -1,10 +1,12 @@
 package org.fossasia.badgemagic.helpers
 
+import kotlinx.serialization.encodeToString
 import org.fossasia.badgemagic.data.BadgeConfig
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 
 object JSONHelper {
-    fun decodeJSON(badgeJSON: String) = Json(JsonConfiguration.Stable).parse(BadgeConfig.serializer(),badgeJSON)
-    fun encodeJSON(badgeData: BadgeConfig) = Json(JsonConfiguration.Stable).stringify(BadgeConfig.serializer(),badgeData)
+    private val jsonFormat = Json { encodeDefaults = true }
+
+    fun decodeJSON(badgeJSON: String): BadgeConfig = Json.decodeFromString(badgeJSON)
+    fun encodeJSON(badgeData: BadgeConfig) = jsonFormat.encodeToString(badgeData)
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,16 +4,12 @@ plugins {
 apply plugin: "com.github.b3er.local.properties"
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 
 def KEYSTORE_FILE = rootProject.file('scripts/key.jks')
 def TRAVIS_BUILD = System.getenv("TRAVIS") == "true" && KEYSTORE_FILE.exists()
 def LOCAL_KEY_PRESENT = project.hasProperty('SIGNING_KEY_FILE') && rootProject.file(SIGNING_KEY_FILE).exists()
-
-androidExtensions {
-    experimental = true
-}
 
 android {
     compileSdkVersion versions.compileSdk
@@ -63,6 +59,7 @@ android {
     }
 
     buildFeatures.dataBinding = true
+    buildFeatures.viewBinding = true
 
     packagingOptions {
         pickFirst 'META-INF/kotlinx-serialization-runtime.kotlin_module'

--- a/android/src/main/java/org/fossasia/badgemagic/BadgeMagicApp.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/BadgeMagicApp.kt
@@ -27,11 +27,13 @@ class BadgeMagicApp : Application() {
         startKoin {
             androidLogger()
             androidContext(applicationContext)
-            modules(listOf(
-                singletonModules,
-                utilModules,
-                viewModelModules
-            ))
+            modules(
+                listOf(
+                    singletonModules,
+                    utilModules,
+                    viewModelModules
+                )
+            )
         }
 
         initLogger()

--- a/android/src/main/java/org/fossasia/badgemagic/adapter/SaveAdapter.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/adapter/SaveAdapter.kt
@@ -84,42 +84,42 @@ class SaveAdapter(private val context: Context?, private val list: List<ConfigIn
                 else -> ContextCompat.getDrawable(itemView.context, android.R.color.transparent)
             }
             text.setTextColor(
-                    when {
-                        selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
-                        else -> ContextCompat.getColor(itemView.context, android.R.color.black)
-                    }
+                when {
+                    selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
+                    else -> ContextCompat.getColor(itemView.context, android.R.color.black)
+                }
             )
             playPause.setColorFilter(
-                    when {
-                        selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
-                        else -> ContextCompat.getColor(itemView.context, android.R.color.black)
-                    }
+                when {
+                    selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
+                    else -> ContextCompat.getColor(itemView.context, android.R.color.black)
+                }
             )
             editButton.setColorFilter(
-                    when {
-                        selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
-                        else -> ContextCompat.getColor(itemView.context, android.R.color.black)
-                    }
+                when {
+                    selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
+                    else -> ContextCompat.getColor(itemView.context, android.R.color.black)
+                }
             )
             delete.setColorFilter(
-                    when {
-                        selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
-                        else -> ContextCompat.getColor(itemView.context, android.R.color.black)
-                    }
+                when {
+                    selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
+                    else -> ContextCompat.getColor(itemView.context, android.R.color.black)
+                }
             )
 
             transfer.setColorFilter(
-                    when {
-                        selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
-                        else -> ContextCompat.getColor(itemView.context, android.R.color.black)
-                    }
+                when {
+                    selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
+                    else -> ContextCompat.getColor(itemView.context, android.R.color.black)
+                }
             )
 
             export.setColorFilter(
-                    when {
-                        selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
-                        else -> ContextCompat.getColor(itemView.context, android.R.color.black)
-                    }
+                when {
+                    selectedPosition != -1 && selectedPosition == adapterPosition -> ContextCompat.getColor(itemView.context, android.R.color.white)
+                    else -> ContextCompat.getColor(itemView.context, android.R.color.black)
+                }
             )
 
             val badge: BadgeConfig = JSONHelper.decodeJSON(item.badgeJSON)

--- a/android/src/main/java/org/fossasia/badgemagic/core/android/log/TimberKt.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/core/android/log/TimberKt.kt
@@ -130,5 +130,5 @@ inline fun wtf(t: Throwable) = Timber.wtf(t)
 /** @suppress */
 @PublishedApi
 internal inline fun log(block: () -> Unit) {
-    if (Timber.treeCount() > 0) block()
+    if (Timber.treeCount > 0) block()
 }

--- a/android/src/main/java/org/fossasia/badgemagic/core/bluetooth/GattClient.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/core/bluetooth/GattClient.kt
@@ -8,12 +8,12 @@ import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.content.Context.BLUETOOTH_SERVICE
-import java.util.LinkedList
 import org.fossasia.badgemagic.core.android.log.Timber
 import org.fossasia.badgemagic.util.BadgeUtils
 import org.fossasia.badgemagic.utils.ByteArrayUtils
 import org.koin.core.KoinComponent
 import org.koin.core.inject
+import java.util.LinkedList
 
 class GattClient : KoinComponent {
 

--- a/android/src/main/java/org/fossasia/badgemagic/core/bluetooth/ScanHelper.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/core/bluetooth/ScanHelper.kt
@@ -51,9 +51,11 @@ class ScanHelper : KoinComponent {
         this.onDeviceFoundCallback = onDeviceFoundCallback
         isScanning = true
 
-        val filters = listOf(ScanFilter.Builder()
-            .setServiceUuid(ParcelUuid(badgeUtils.currentDevice.serviceID))
-            .build())
+        val filters = listOf(
+            ScanFilter.Builder()
+                .setServiceUuid(ParcelUuid(badgeUtils.currentDevice.serviceID))
+                .build()
+        )
 
         val settings = ScanSettings.Builder()
             .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)

--- a/android/src/main/java/org/fossasia/badgemagic/data/badge/Badges.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/data/badge/Badges.kt
@@ -3,12 +3,16 @@ package org.fossasia.badgemagic.data.badge
 import java.util.UUID
 
 enum class Badges(val device: DeviceID) {
-    LSLED(DeviceID(
-        UUID.fromString("0000fee0-0000-1000-8000-00805f9b34fb"),
-        UUID.fromString("0000fee1-0000-1000-8000-00805f9b34fb")
-    )),
-    VBLAB(DeviceID(
-        UUID.fromString("0000fff0-0000-1000-8000-00805f9b34fb"),
-        UUID.fromString("0000fff1-0000-1000-8000-00805f9b34fb")
-    ));
+    LSLED(
+        DeviceID(
+            UUID.fromString("0000fee0-0000-1000-8000-00805f9b34fb"),
+            UUID.fromString("0000fee1-0000-1000-8000-00805f9b34fb")
+        )
+    ),
+    VBLAB(
+        DeviceID(
+            UUID.fromString("0000fff0-0000-1000-8000-00805f9b34fb"),
+            UUID.fromString("0000fff1-0000-1000-8000-00805f9b34fb")
+        )
+    );
 }

--- a/android/src/main/java/org/fossasia/badgemagic/ui/EditBadgeActivity.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/EditBadgeActivity.kt
@@ -9,7 +9,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.activity_edit_badge.*
 import org.fossasia.badgemagic.R
 import org.fossasia.badgemagic.data.BadgeConfig
 import org.fossasia.badgemagic.databinding.ActivityEditBadgeBinding
@@ -28,32 +27,38 @@ class EditBadgeActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val activityDrawBinding = DataBindingUtil.setContentView<ActivityEditBadgeBinding>(this, R.layout.activity_edit_badge)
-        activityDrawBinding.viewModel = viewModel
+        val binding = DataBindingUtil.setContentView<ActivityEditBadgeBinding>(this, R.layout.activity_edit_badge)
+        binding.viewModel = viewModel
 
         if (intent.hasExtra("badgeJSON") && intent.hasExtra("fileName")) {
             viewModel.drawingJSON.set(intent?.extras?.getString("badgeJSON"))
             fileName = intent?.extras?.getString("fileName") ?: ""
         }
 
-        viewModel.savedButton.observe(this, Observer {
-            if (it) {
-                val badgeConfig = SendingUtils.getBadgeFromJSON(viewModel.drawingJSON.get() ?: "{}")
-                badgeConfig.hexStrings = Converters.convertBitmapToLEDHex(
-                    Converters.convertStringsToLEDHex(draw_layout.getCheckedList()),
-                    false
-                )
-                StoreAsync(fileName, badgeConfig, viewModel, storageUtils).execute()
-                Toast.makeText(this, R.string.saved_edited_badge, Toast.LENGTH_LONG).show()
-                finish()
+        viewModel.savedButton.observe(
+            this,
+            Observer {
+                if (it) {
+                    val badgeConfig = SendingUtils.getBadgeFromJSON(viewModel.drawingJSON.get() ?: "{}")
+                    badgeConfig.hexStrings = Converters.convertBitmapToLEDHex(
+                        Converters.convertStringsToLEDHex(binding.drawLayout.getCheckedList()),
+                        false
+                    )
+                    StoreAsync(fileName, badgeConfig, viewModel, storageUtils).execute()
+                    Toast.makeText(this, R.string.saved_edited_badge, Toast.LENGTH_LONG).show()
+                    finish()
+                }
             }
-        })
+        )
 
-        viewModel.resetButton.observe(this, Observer {
-            if (it) {
-                draw_layout.resetCheckListWithDummyData()
+        viewModel.resetButton.observe(
+            this,
+            Observer {
+                if (it) {
+                    binding.drawLayout.resetCheckListWithDummyData()
+                }
             }
-        })
+        )
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/android/src/main/java/org/fossasia/badgemagic/ui/EditClipartActivity.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/EditClipartActivity.kt
@@ -8,7 +8,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.activity_edit_clipart.*
 import org.fossasia.badgemagic.R
 import org.fossasia.badgemagic.databinding.ActivityEditClipartBinding
 import org.fossasia.badgemagic.util.Converters
@@ -33,22 +32,28 @@ class EditClipartActivity : AppCompatActivity() {
             editClipartViewModel.drawingJSON.set(Converters.convertDrawableToLEDHex(storageUtils.getClipartFromPath(fileName), false))
         }
 
-        editClipartViewModel.savedButton.observe(this, Observer {
-            if (it) {
-                if (storageUtils.saveEditedClipart(Converters.convertStringsToLEDHex(draw_layout.getCheckedList()), fileName)) {
-                    Toast.makeText(this, R.string.clipart_saved_success, Toast.LENGTH_LONG).show()
-                    editClipartViewModel.updateClipArts()
-                } else
-                    Toast.makeText(this, R.string.clipart_saved_error, Toast.LENGTH_LONG).show()
-                finish()
+        editClipartViewModel.savedButton.observe(
+            this,
+            Observer {
+                if (it) {
+                    if (storageUtils.saveEditedClipart(Converters.convertStringsToLEDHex(activityDrawBinding.drawLayout.getCheckedList()), fileName)) {
+                        Toast.makeText(this, R.string.clipart_saved_success, Toast.LENGTH_LONG).show()
+                        editClipartViewModel.updateClipArts()
+                    } else
+                        Toast.makeText(this, R.string.clipart_saved_error, Toast.LENGTH_LONG).show()
+                    finish()
+                }
             }
-        })
+        )
 
-        editClipartViewModel.resetButton.observe(this, Observer {
-            if (it) {
-                draw_layout.resetCheckListWithDummyData()
+        editClipartViewModel.resetButton.observe(
+            this,
+            Observer {
+                if (it) {
+                    activityDrawBinding.drawLayout.resetCheckListWithDummyData()
+                }
             }
-        })
+        )
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/android/src/main/java/org/fossasia/badgemagic/ui/custom/DrawBadgeLayout.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/custom/DrawBadgeLayout.kt
@@ -73,7 +73,8 @@ class DrawBadgeLayout(context: Context?, attrs: AttributeSet?) : View(context, a
 
         setMeasuredDimension(
             MeasureSpec.makeMeasureSpec(originalWidth, MeasureSpec.EXACTLY),
-            MeasureSpec.makeMeasureSpec(calculatedHeight, MeasureSpec.EXACTLY))
+            MeasureSpec.makeMeasureSpec(calculatedHeight, MeasureSpec.EXACTLY)
+        )
     }
 
     @SuppressLint("DrawAllocation")
@@ -90,12 +91,14 @@ class DrawBadgeLayout(context: Context?, attrs: AttributeSet?) : View(context, a
         for (i in 0 until badgeHeight) {
             cells.add(Cell())
             for (j in 0 until badgeWidth) {
-                cells[i].list.add(Rect(
-                    (offsetXToAdd * 2) + j * singleCell,
-                    (offsetXToAdd * 2) + i * singleCell,
-                    (offsetXToAdd * 2) + j * singleCell + singleCell,
-                    (offsetXToAdd * 2) + i * singleCell + singleCell
-                ))
+                cells[i].list.add(
+                    Rect(
+                        (offsetXToAdd * 2) + j * singleCell,
+                        (offsetXToAdd * 2) + i * singleCell,
+                        (offsetXToAdd * 2) + j * singleCell + singleCell,
+                        (offsetXToAdd * 2) + i * singleCell + singleCell
+                    )
+                )
             }
         }
 

--- a/android/src/main/java/org/fossasia/badgemagic/ui/custom/PreviewBadge.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/custom/PreviewBadge.kt
@@ -99,7 +99,8 @@ class PreviewBadge : View {
 
         setMeasuredDimension(
             MeasureSpec.makeMeasureSpec(originalWidth, MeasureSpec.EXACTLY),
-            MeasureSpec.makeMeasureSpec(calculatedHeight.toInt(), MeasureSpec.EXACTLY))
+            MeasureSpec.makeMeasureSpec(calculatedHeight.toInt(), MeasureSpec.EXACTLY)
+        )
     }
 
     public override fun onSaveInstanceState(): Parcelable? {
@@ -144,12 +145,14 @@ class PreviewBadge : View {
         for (i in 0 until badgeHeight) {
             cells.add(Cell())
             for (j in 0 until badgeWidth) {
-                cells[i].list.add(Rect(
-                    (offsetXToAdd * 2) + j * singleCell,
-                    (offsetXToAdd * 2) + i * singleCell,
-                    (offsetXToAdd * 2) + j * singleCell + singleCell,
-                    (offsetXToAdd * 2) + i * singleCell + singleCell
-                ))
+                cells[i].list.add(
+                    Rect(
+                        (offsetXToAdd * 2) + j * singleCell,
+                        (offsetXToAdd * 2) + i * singleCell,
+                        (offsetXToAdd * 2) + j * singleCell + singleCell,
+                        (offsetXToAdd * 2) + i * singleCell + singleCell
+                    )
+                )
             }
         }
         bgBounds = RectF((offsetXToAdd).toFloat(), (offsetXToAdd).toFloat(), ((singleCell * badgeWidth) + (offsetXToAdd * 3)).toFloat(), ((singleCell * badgeHeight) + (offsetXToAdd * 3)).toFloat())

--- a/android/src/main/java/org/fossasia/badgemagic/ui/custom/knob/Croller.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/custom/knob/Croller.kt
@@ -285,8 +285,13 @@ class Croller : View {
         progressPrimaryDisabledColor = a.getColor(R.styleable.Croller_progress_primary_disable_color, this.progressPrimaryDisabledColor)
         progressSecondaryDisabledColor = a.getColor(R.styleable.Croller_progress_secondary_disable_color, this.progressSecondaryDisabledColor)
 
-        labelSize = a.getDimension(R.styleable.Croller_label_size, TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
-            this.labelSize, resources.displayMetrics).toInt().toFloat())
+        labelSize = a.getDimension(
+            R.styleable.Croller_label_size,
+            TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                this.labelSize, resources.displayMetrics
+            ).toInt().toFloat()
+        )
         labelColor = a.getColor(R.styleable.Croller_label_color, this.labelColor)
         setlabelDisabledColor(a.getColor(R.styleable.Croller_label_disabled_color, labelDisabledColor))
         labelFont = a.getString(R.styleable.Croller_label_font)
@@ -450,8 +455,11 @@ class Croller : View {
             else
                 circlePaint.color = this.mainCircleDisabledColor
             canvas.drawCircle(midx, midy, mainCircleRadius, circlePaint)
-            canvas.drawText(this.label
-                ?: "", midx, midy + (radius * 1.1).toFloat() - textPaint.fontMetrics.descent, textPaint)
+            canvas.drawText(
+                this.label
+                    ?: "",
+                midx, midy + (radius * 1.1).toFloat() - textPaint.fontMetrics.descent, textPaint
+            )
             canvas.drawLine(x1, y1, x2, y2, linePaint)
         } else {
 
@@ -512,8 +520,11 @@ class Croller : View {
             else
                 circlePaint.color = this.mainCircleDisabledColor
             canvas.drawCircle(midx, midy, mainCircleRadius, circlePaint)
-            canvas.drawText(this.label
-                ?: "", midx, midy + (radius * 1.1).toFloat() - textPaint.fontMetrics.descent, textPaint)
+            canvas.drawText(
+                this.label
+                    ?: "",
+                midx, midy + (radius * 1.1).toFloat() - textPaint.fontMetrics.descent, textPaint
+            )
             canvas.drawLine(x1, y1, x2, y2, linePaint)
         }
     }

--- a/android/src/main/java/org/fossasia/badgemagic/ui/fragments/AboutFragment.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/fragments/AboutFragment.kt
@@ -11,8 +11,8 @@ import de.psdev.licensesdialog.licenses.ApacheSoftwareLicense20
 import de.psdev.licensesdialog.licenses.MITLicense
 import de.psdev.licensesdialog.model.Notice
 import de.psdev.licensesdialog.model.Notices
-import kotlinx.android.synthetic.main.fragment_about_us.*
 import org.fossasia.badgemagic.R
+import org.fossasia.badgemagic.databinding.FragmentAboutUsBinding
 import org.fossasia.badgemagic.ui.base.BaseFragment
 
 class AboutFragment : BaseFragment() {
@@ -20,30 +20,36 @@ class AboutFragment : BaseFragment() {
     companion object {
         @JvmStatic
         fun newInstance() =
-                AboutFragment()
+            AboutFragment()
     }
 
+    private var _binding: FragmentAboutUsBinding? = null
+    val binding get() = _binding!!
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_about_us, container, false)
+        _binding = FragmentAboutUsBinding.inflate(layoutInflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        about_fossasia.setOnClickListener {
-            contributorsLink()
-        }
+        with(binding) {
+            aboutFossasia.setOnClickListener {
+                contributorsLink()
+            }
 
-        githubLayout.setOnClickListener {
-            github()
-        }
+            githubLayout.setOnClickListener {
+                github()
+            }
 
-        ll_about_license.setOnClickListener {
-            license()
-        }
+            llAboutLicense.setOnClickListener {
+                license()
+            }
 
-        ll_about_libs.setOnClickListener {
-            libraryLicenseDialog()
+            llAboutLibs.setOnClickListener {
+                libraryLicenseDialog()
+            }
         }
     }
 
@@ -72,50 +78,55 @@ class AboutFragment : BaseFragment() {
         val notices = Notices()
 
         notices.addNotice(
-                Notice(
-                        context?.getString(R.string.moshi),
-                        context?.getString(R.string.moshi_github),
-                        context?.getString(R.string.moshi_copy),
-                        ApacheSoftwareLicense20()
-                )
+            Notice(
+                context?.getString(R.string.moshi),
+                context?.getString(R.string.moshi_github),
+                context?.getString(R.string.moshi_copy),
+                ApacheSoftwareLicense20()
+            )
         )
         notices.addNotice(
-                Notice(
-                        context?.getString(R.string.gif),
-                        context?.getString(R.string.gif_github),
-                        context?.getString(R.string.gif_copy),
-                        ApacheSoftwareLicense20()
-                )
+            Notice(
+                context?.getString(R.string.gif),
+                context?.getString(R.string.gif_github),
+                context?.getString(R.string.gif_copy),
+                ApacheSoftwareLicense20()
+            )
         )
         notices.addNotice(
-                Notice(
-                        context?.getString(R.string.timber),
-                        context?.getString(R.string.timber_github),
-                        context?.getString(R.string.timber_copy),
-                        MITLicense()
-                )
+            Notice(
+                context?.getString(R.string.timber),
+                context?.getString(R.string.timber_github),
+                context?.getString(R.string.timber_copy),
+                MITLicense()
+            )
         )
         notices.addNotice(
-                Notice(
-                        context?.getString(R.string.scanner),
-                        context?.getString(R.string.scanner_github),
-                        context?.getString(R.string.scanner_copy),
-                        ApacheSoftwareLicense20()
-                )
+            Notice(
+                context?.getString(R.string.scanner),
+                context?.getString(R.string.scanner_github),
+                context?.getString(R.string.scanner_copy),
+                ApacheSoftwareLicense20()
+            )
         )
         notices.addNotice(
-                Notice(
-                        context?.getString(R.string.licences),
-                        context?.getString(R.string.licences_github),
-                        context?.getString(R.string.licences_copy),
-                        ApacheSoftwareLicense20()
-                )
+            Notice(
+                context?.getString(R.string.licences),
+                context?.getString(R.string.licences_github),
+                context?.getString(R.string.licences_copy),
+                ApacheSoftwareLicense20()
+            )
         )
 
         LicensesDialog.Builder(context)
-                .setNotices(notices)
-                .setIncludeOwnLicense(true)
-                .build()
-                .show()
+            .setNotices(notices)
+            .setIncludeOwnLicense(true)
+            .build()
+            .show()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
     }
 }

--- a/android/src/main/java/org/fossasia/badgemagic/ui/fragments/DrawFragment.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/fragments/DrawFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.fragment_draw.*
 import org.fossasia.badgemagic.R
 import org.fossasia.badgemagic.databinding.FragmentDrawBinding
 import org.fossasia.badgemagic.ui.base.BaseFragment
@@ -28,8 +27,11 @@ class DrawFragment : BaseFragment() {
     private val drawViewModel by viewModel<DrawViewModel>()
     private val storageUtils: StorageUtils by inject()
 
+    private var _binding: FragmentDrawBinding? = null
+    val binding get() = _binding!!
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val binding = DataBindingUtil.inflate<FragmentDrawBinding>(inflater, R.layout.fragment_draw, container, false)
+        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_draw, container, false)
         binding.viewModel = drawViewModel
         return binding.root
     }
@@ -37,20 +39,31 @@ class DrawFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        drawViewModel.savedButton.observe(this, Observer {
-            if (it) {
-                if (storageUtils.saveClipArt(Converters.convertStringsToLEDHex(draw_layout.getCheckedList()))) {
-                    Toast.makeText(requireContext(), R.string.clipart_saved_success, Toast.LENGTH_LONG).show()
-                    drawViewModel.updateCliparts()
-                } else
-                    Toast.makeText(requireContext(), R.string.clipart_saved_error, Toast.LENGTH_LONG).show()
+        drawViewModel.savedButton.observe(
+            this,
+            Observer {
+                if (it) {
+                    if (storageUtils.saveClipArt(Converters.convertStringsToLEDHex(binding.drawLayout.getCheckedList()))) {
+                        Toast.makeText(requireContext(), R.string.clipart_saved_success, Toast.LENGTH_LONG).show()
+                        drawViewModel.updateCliparts()
+                    } else
+                        Toast.makeText(requireContext(), R.string.clipart_saved_error, Toast.LENGTH_LONG).show()
+                }
             }
-        })
+        )
 
-        drawViewModel.resetButton.observe(this, Observer {
-            if (it) {
-                draw_layout.resetCheckListWithDummyData()
+        drawViewModel.resetButton.observe(
+            this,
+            Observer {
+                if (it) {
+                    binding.drawLayout.resetCheckListWithDummyData()
+                }
             }
-        })
+        )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
     }
 }

--- a/android/src/main/java/org/fossasia/badgemagic/ui/fragments/SavedClipartFragment.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/fragments/SavedClipartFragment.kt
@@ -33,10 +33,13 @@ class SavedClipartFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.getStorageClipartLiveData().observe(viewLifecycleOwner, Observer { list ->
-            viewModel.adapter.setList(
-                list.map { SavedClipart(it.key, ImageUtils.convertToBitmap(it.value)) }
-            )
-        })
+        viewModel.getStorageClipartLiveData().observe(
+            viewLifecycleOwner,
+            Observer { list ->
+                viewModel.adapter.setList(
+                    list.map { SavedClipart(it.key, ImageUtils.convertToBitmap(it.value)) }
+                )
+            }
+        )
     }
 }

--- a/android/src/main/java/org/fossasia/badgemagic/ui/fragments/SettingsFragment.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/fragments/SettingsFragment.kt
@@ -35,25 +35,31 @@ class SettingsFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.changedLanguage.observe(viewLifecycleOwner, Observer {
+        viewModel.changedLanguage.observe(
+            viewLifecycleOwner,
+            Observer {
 
-            Snackbar
-                .make(view, requireContext().getString(R.string.change_language), Snackbar.LENGTH_INDEFINITE)
-                .setAction("RESTART") {
+                Snackbar
+                    .make(view, requireContext().getString(R.string.change_language), Snackbar.LENGTH_INDEFINITE)
+                    .setAction("RESTART") {
 
-                    activity?.let {
-                        it.finishAffinity()
-                        startActivity(requireActivity().intent)
+                        activity?.let {
+                            it.finishAffinity()
+                            startActivity(requireActivity().intent)
+                        }
                     }
-                }
-                .show()
-        })
+                    .show()
+            }
+        )
 
-        viewModel.changedBadge.observe(viewLifecycleOwner, Observer {
+        viewModel.changedBadge.observe(
+            viewLifecycleOwner,
+            Observer {
 
-            Snackbar
-                .make(view, requireContext().getString(R.string.changed_badge) + " ${prefsUtils.selectedBadge}", Snackbar.LENGTH_LONG)
-                .show()
-        })
+                Snackbar
+                    .make(view, requireContext().getString(R.string.changed_badge) + " ${prefsUtils.selectedBadge}", Snackbar.LENGTH_LONG)
+                    .show()
+            }
+        )
     }
 }

--- a/android/src/main/java/org/fossasia/badgemagic/util/BluetoothAdapter.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/util/BluetoothAdapter.kt
@@ -33,10 +33,10 @@ class BluetoothAdapter(appContext: Context) {
         if (lm is LocationManager) {
             if (!lm.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
                 AlertDialog.Builder(context)
-                        .setMessage(R.string.no_gps_enabled)
-                        .setPositiveButton("OK") { _, _ -> context.startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)) }
-                        .setNegativeButton("Cancel", null)
-                        .show()
+                    .setMessage(R.string.no_gps_enabled)
+                    .setPositiveButton("OK") { _, _ -> context.startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)) }
+                    .setNegativeButton("Cancel", null)
+                    .show()
                 return false
             }
             return true

--- a/android/src/main/java/org/fossasia/badgemagic/util/Converters.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/util/Converters.kt
@@ -8,11 +8,11 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.VectorDrawable
 import android.util.SparseArray
+import org.fossasia.badgemagic.data.badge_preview.CheckList
+import org.fossasia.badgemagic.device.DataToByteArrayConverter
 import java.math.BigInteger
 import kotlin.math.ceil
 import kotlin.math.floor
-import org.fossasia.badgemagic.data.badge_preview.CheckList
-import org.fossasia.badgemagic.device.DataToByteArrayConverter
 
 const val DRAWABLE_START = '«'
 const val DRAWABLE_END = '»'
@@ -104,7 +104,8 @@ object Converters {
         for (i in 0 until height) {
             for (j in 0 until width) {
                 if (image[i][j] != -1)
-                    list[i].add(image[i][j]
+                    list[i].add(
+                        image[i][j]
                     )
             }
         }
@@ -290,7 +291,8 @@ object Converters {
         val newBitmap = Bitmap.createBitmap(list[0].list.size, list.size, Bitmap.Config.ARGB_8888)
         for (i in 0 until list.size) {
             for (j in 0 until list[0].list.size) {
-                newBitmap.setPixel(j, i,
+                newBitmap.setPixel(
+                    j, i,
                     if (list[i].list[j])
                         Color.BLACK
                     else

--- a/android/src/main/java/org/fossasia/badgemagic/util/LocaleManager.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/util/LocaleManager.kt
@@ -2,13 +2,14 @@ package org.fossasia.badgemagic.util
 
 import android.content.Context
 import android.content.res.Configuration
-import java.util.Locale
 import org.fossasia.badgemagic.data.Language
+import java.util.Locale
 
 object LocaleManager {
 
     fun setLocale(context: Context?): Context {
-        return updateResources(context as Context,
+        return updateResources(
+            context as Context,
             Language.values()[PreferenceUtils(context).selectedLanguage].locale
         )
     }

--- a/android/src/main/java/org/fossasia/badgemagic/util/SendingUtils.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/util/SendingUtils.kt
@@ -60,27 +60,35 @@ object SendingUtils {
     }
 
     fun returnDefaultMessage(): DataToSend {
-        return DataToSend(listOf(Message(
-            Converters.convertTextToLEDHex(
-                " ",
-                false
-            ).second,
-            flash = false,
-            marquee = false,
-            speed = Speed.ONE,
-            mode = Mode.LEFT
-        )))
+        return DataToSend(
+            listOf(
+                Message(
+                    Converters.convertTextToLEDHex(
+                        " ",
+                        false
+                    ).second,
+                    flash = false,
+                    marquee = false,
+                    speed = Speed.ONE,
+                    mode = Mode.LEFT
+                )
+            )
+        )
     }
 
     fun returnMessageWithJSON(badgeJSON: String): DataToSend {
         val badgeConfig = getBadgeFromJSON(badgeJSON)
-        return DataToSend(listOf(Message(
-            Converters.fixLEDHex(badgeConfig.hexStrings, badgeConfig.isInverted),
-            badgeConfig.isFlash,
-            badgeConfig.isMarquee,
-            badgeConfig.speed,
-            badgeConfig.mode
-        )))
+        return DataToSend(
+            listOf(
+                Message(
+                    Converters.fixLEDHex(badgeConfig.hexStrings, badgeConfig.isInverted),
+                    badgeConfig.isFlash,
+                    badgeConfig.isMarquee,
+                    badgeConfig.speed,
+                    badgeConfig.mode
+                )
+            )
+        )
     }
 
     fun configToJSON(data: Message, invertLED: Boolean): String {

--- a/android/src/main/java/org/fossasia/badgemagic/util/StorageUtils.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/util/StorageUtils.kt
@@ -4,10 +4,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
-import java.io.BufferedReader
-import java.io.File
-import java.io.FileOutputStream
-import java.io.InputStreamReader
 import org.fossasia.badgemagic.data.BadgeConfig
 import org.fossasia.badgemagic.data.CONF_FLASH
 import org.fossasia.badgemagic.data.CONF_HEX_STRINGS
@@ -18,6 +14,10 @@ import org.fossasia.badgemagic.data.CONF_SPEED
 import org.fossasia.badgemagic.data.ConfigInfo
 import org.fossasia.badgemagic.helpers.JSONHelper
 import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStreamReader
 
 class StorageUtils(val context: Context) {
     private val externalStorageDir = context.getExternalFilesDir(null)?.absolutePath
@@ -112,11 +112,11 @@ class StorageUtils(val context: Context) {
         return try {
             val obj = JSONObject(jsonString)
             return obj.has(CONF_HEX_STRINGS) &&
-                    obj.has(CONF_INVERTED) &&
-                    obj.has(CONF_MARQUEE) &&
-                    obj.has(CONF_FLASH) &&
-                    obj.has(CONF_MODE) &&
-                    obj.has(CONF_SPEED)
+                obj.has(CONF_INVERTED) &&
+                obj.has(CONF_MARQUEE) &&
+                obj.has(CONF_FLASH) &&
+                obj.has(CONF_MODE) &&
+                obj.has(CONF_SPEED)
         } catch (e: Exception) {
             false
         }

--- a/android/src/main/res/layout/activity_drawer.xml
+++ b/android/src/main/res/layout/activity_drawer.xml
@@ -9,6 +9,7 @@
     tools:openDrawer="start">
 
     <include
+        android:id="@+id/app_bar"
         layout="@layout/app_bar_drawer"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/android/src/main/res/layout/effects_layout.xml
+++ b/android/src/main/res/layout/effects_layout.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/effects_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">

--- a/android/src/main/res/layout/fragment_main_textart.xml
+++ b/android/src/main/res/layout/fragment_main_textart.xml
@@ -72,7 +72,9 @@
                 </LinearLayout>
             </LinearLayout>
 
-            <include layout="@layout/sections_tab" />
+            <include
+                android:id="@+id/sections_tab"
+                layout="@layout/sections_tab" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/android/src/main/res/layout/sections_tab.xml
+++ b/android/src/main/res/layout/sections_tab.xml
@@ -60,7 +60,7 @@
     </androidx.recyclerview.widget.RecyclerView>
 
     <include
-        android:id="@+id/effectsLayout"
+        android:id="@+id/effects"
         layout="@layout/effects_layout"
         android:visibility="gone" />
 </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "gradle.plugin.com.github.b3er.local.properties:local-properties-plugin:1.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$versions.kotlin_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ android.enableJetifier=true
 android.useAndroidX=true
 
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=1024m 
+kotlin.native.ignoreDisabledTargets=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/versions.gradle
+++ b/versions.gradle
@@ -5,7 +5,7 @@ versions.buildTools = '29.0.2'
 versions.minSdk = 21
 versions.targetSdk = 29
 
-versions.kotlin_version = '1.3.61'
+versions.kotlin_version = '1.9.0'
 
 versions.koin_version = '2.0.1'
 versions.moshi_version = '1.8.0'


### PR DESCRIPTION
Fixes #893 here.

The project fails to build due to the old Kotlin version that can't use [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) library. Also, the library changed its dependencies declaration from the older versions.
After several attempts to solve the unsupported versions and the resulting issues due to changing the versions in the project, what works eventually is the following:

Changes: 
1. Upgrade Kotlin versions in the project to 1.9.0
2. Upgrade Gradle version to 6.8.3 and Android Gradle Plugin to 4.2.2 to be compatible with the Kotlin version.
3. Upgrade kotlinx serialization library version to 1.6.2 and change the obsolete dependency name from `kotlinx-serialization-runtime` to `kotlinx-serialization-json` and change the code in `JSONHelper.kt` file to the new API provided by the library.
4. Due to the previous upgrades, `kotlin-android-extensions` plugin (which provides Kotlin synthetics and parcelization) is now unsupported because it was an experimental plugin, and it is not possible to build the project with it. Therefore, we need to migrate from Kotlin synthetics to Jetpack View Binding. In addition, we need to use `kotlin-parcelize` plugin for parcelization.
5. After the migration to ViewBinding, the plugin `com.diffplug.spotless` and `ktlint()` are now working properly and they automatically modified the whole project to comply with the Kotlin linting.