### PR TITLE
fix: Right animation doesn't start immediately when selected

### DIFF
--- a/android/src/main/java/org/fossasia/badgemagic/ui/custom/PreviewBadge.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/custom/PreviewBadge.kt
@@ -232,7 +232,7 @@ class PreviewBadge : View {
                         val rightCondition = validMarquee || flashLEDOn &&
                             i < checkList.size &&
                             j < checkList[i].list.size &&
-                            checkList[i].list[(animationValue + j + checkListLength - badgeWidth / 2).rem(checkListLength)]
+                            checkList[i].list[(animationValue + j + checkListLength - badgeWidth).rem(checkListLength)]
 
                         drawLED(
                             rightCondition,


### PR DESCRIPTION
Fixes #895 

Changes:
Fixed the issue and now the **Right** animation starts to slide immediately in the preview once selected.

Screenshots for the change:

Before:

https://github.com/fossasia/badgemagic-android/assets/52531091/14d10c82-324e-4f09-8ae4-bfceca2d910b

After:

https://github.com/fossasia/badgemagic-android/assets/52531091/59b522b1-8564-4614-92ad-fcde0c7fc35f

