### PR TITLE
chore: fix build errors caused by lint check

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,9 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.fossasia.badgemagic">
 
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
+	<uses-feature android:name="android.hardware.bluetooth" android:required="true"/>
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,7 +2,7 @@ ext.versions = [:]
 
 versions.compileSdk = 29
 versions.buildTools = '29.0.2'
-versions.minSdk = 21
+versions.minSdk = 24
 versions.targetSdk = 29
 
 versions.kotlin_version = '1.9.0'


### PR DESCRIPTION
Fixes #899

Changes:

- Add missing permissions (lint required)
- Change minSdkVersion to 24 (NewApi lint error)