### PR TITLE
Fix warning flood

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     implementation project(':BadgeMagicModule')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin_version}"
+	implementation "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin_version}"
 
     kapt "androidx.databinding:compiler:3.2.0-alpha11"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.4.0'
 
     //Timber
-    implementation 'com.jakewharton.timber:timber:5.0.1'
+    implementation 'com.jakewharton.timber:timber:4.7.1'
 
     implementation 'no.nordicsemi.android.support.v18:scanner:1.6.0'
 

--- a/android/src/main/java/org/fossasia/badgemagic/core/android/log/TimberKt.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/core/android/log/TimberKt.kt
@@ -130,5 +130,5 @@ inline fun wtf(t: Throwable) = Timber.wtf(t)
 /** @suppress */
 @PublishedApi
 internal inline fun log(block: () -> Unit) {
-    if (Timber.treeCount > 0) block()
+    if (Timber.treeCount() > 0) block()
 }


### PR DESCRIPTION
Fixes #912

Changes: 

- fix build log was flooded with warnings caused by having different versions of kotlin module
- revert `Timber` to 4.7.1. Current build system for some reason cannot load `Timber` 5.0.1 lint check. This cause a lot of garbage in build log.