### PR TITLE
fix android build check failed on PRs

### DIFF
--- a/.github/workflows/branch-push.yml
+++ b/.github/workflows/branch-push.yml
@@ -49,6 +49,8 @@ jobs:
           path: android/build/outputs/bundle/release
 
       - name: Upload APK to apk branch
+        # Skip upload APK for pull requests
+        if: ${{ github.event_name != 'pull_request'}} 
         run: |
           git config --global user.name "${{ github.workflow }}"
           git config --global user.email "gh-actions@${{ github.repository_owner }}"


### PR DESCRIPTION

Changes: 

- Skip uploading APK on PRs. Pull requests don't have permission to upload to the APK branch. This causes checks to fail. So build check CI should skip this step for PRs.