### PR TITLE
Ugrade: changed the compilesdk to v33 and targetsdk to v33

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId 'org.fossasia.badgemagic'
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
-        versionCode 12
-        versionName '1.8.2'
+        versionCode 13
+        versionName '1.8.3'
         vectorDrawables.useSupportLibrary = true
     }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
             android:name=".ui.DrawerActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.MAIN" />
@@ -49,7 +50,7 @@
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
-        <activity android:name=".ui.EditBadgeActivity" android:screenOrientation="landscape"/>
+        <activity android:name=".ui.EditBadgeActivity"  android:screenOrientation="landscape"/>
         <activity android:name=".ui.EditClipartActivity" android:screenOrientation="landscape"/>
 
         <provider

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,0 +1,1 @@
+Re-Release

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 android.enableJetifier=true
 android.useAndroidX=true
 
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=1024m 
+org.gradle.jvmargs=--add-opens java.base/java.io=ALL-UNNAMED
 kotlin.native.ignoreDisabledTargets=true

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,12 +1,12 @@
 ext.versions = [:]
 
-versions.compileSdk = 29
+versions.compileSdk = 33
 versions.buildTools = '29.0.2'
 versions.minSdk = 24
-versions.targetSdk = 29
+versions.targetSdk = 33
 
 versions.kotlin_version = '1.9.0'
 
 versions.koin_version = '2.0.1'
 versions.moshi_version = '1.8.0'
-versions.leak_canary = '2.0-alpha-2'
+versions.leak_canary = '3.0-alpha-4'


### PR DESCRIPTION
Fixes #925 

Changes: changed the target sdk version to 33 and compile SDK version to 33. Also, upgraded the leak canary dependency to match with the SDK versions.
