### PR TITLE
feat: added prominent disclosure dialogs

### DIFF
--- a/android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt
@@ -1,0 +1,105 @@
+package org.fossasia.badgemagic.others
+
+import android.Manifest
+import android.app.Activity
+import android.app.AlertDialog
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+
+class BadgeMagicPermission private constructor() {
+
+    companion object {
+        private const val REQUEST_PERMISSION_CODE = 10
+        val instance: BadgeMagicPermission by lazy { BadgeMagicPermission() }
+    }
+
+    val allPermissions = arrayOf(
+        Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.BLUETOOTH,
+        Manifest.permission.BLUETOOTH_ADMIN,
+        Manifest.permission.BLUETOOTH_PRIVILEGED,
+    )
+
+    val storagePermissions = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+
+    val locationPermissions = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+
+    val bluetoothPermissions = arrayOf(
+        Manifest.permission.BLUETOOTH,
+        Manifest.permission.BLUETOOTH_ADMIN,
+        Manifest.permission.BLUETOOTH_PRIVILEGED,
+    )
+
+    val ALL_PERMISSION = 100
+    val STORAGE_PERMISSION = 101
+    val LOCATION_PERMISSION = 102
+    val BLUETOOTH_PERMISSION = 103
+
+    val listPermissionsNeeded = arrayListOf<String>()
+
+    fun checkPermissions(activity: Activity, mode: Int) {
+        listPermissionsNeeded.clear()
+        if (mode == ALL_PERMISSION) {
+            for (permission in allPermissions) {
+                if (ContextCompat.checkSelfPermission(activity, permission) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                    listPermissionsNeeded.add(permission)
+                }
+            }
+        }
+        if (mode == STORAGE_PERMISSION) {
+            for (permission in storagePermissions) {
+                if (ContextCompat.checkSelfPermission(activity, permission) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                    listPermissionsNeeded.add(permission)
+                }
+            }
+        }
+        if (mode == LOCATION_PERMISSION) {
+            for (permission in locationPermissions) {
+                if (ContextCompat.checkSelfPermission(activity, permission) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                    listPermissionsNeeded.add(permission)
+                }
+            }
+        }
+        if (mode == BLUETOOTH_PERMISSION) {
+            for (permission in bluetoothPermissions) {
+                if (ContextCompat.checkSelfPermission(activity, permission) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                    listPermissionsNeeded.add(permission)
+                }
+            }
+        }
+        if (listPermissionsNeeded.size > 0) {
+            for (permission in listPermissionsNeeded) {
+                if (permission == Manifest.permission.ACCESS_FINE_LOCATION) {
+                    val builder = AlertDialog.Builder(activity)
+                    builder.setTitle("Location Permission Disclosure")
+                    builder.setMessage("Badge Magic requires access to location data to enable the transfer of data to LED Badges via Bluetooth LE.")
+                    builder.setCancelable(false)
+                    builder.setPositiveButton("ACCEPT") { _, _ ->
+                        activity.requestPermissions(locationPermissions, REQUEST_PERMISSION_CODE)
+                    }
+                    builder.setNegativeButton("DENY") { _, _ ->
+                        Toast.makeText(activity, "Please grant the permission", Toast.LENGTH_SHORT).show()
+                        activity.requestPermissions(locationPermissions, REQUEST_PERMISSION_CODE)
+                    }
+                    builder.show()
+                } else if (permission == Manifest.permission.WRITE_EXTERNAL_STORAGE) {
+                    val builder = AlertDialog.Builder(activity)
+                    builder.setTitle("Storage Permission Disclosure")
+                    builder.setMessage("Badge Magic requires access to storage to enable the storage and import of data.")
+                    builder.setCancelable(false)
+                    builder.setPositiveButton("ACCEPT") { _, _ ->
+                        activity.requestPermissions(storagePermissions, REQUEST_PERMISSION_CODE)
+                    }
+                    builder.setNegativeButton("DENY") { _, _ ->
+                        Toast.makeText(activity, "Please grant the permission", Toast.LENGTH_SHORT).show()
+                        activity.requestPermissions(storagePermissions, REQUEST_PERMISSION_CODE)
+                    }
+                    builder.show()
+                } else if (permission == Manifest.permission.BLUETOOTH || permission == Manifest.permission.BLUETOOTH_ADMIN || permission == Manifest.permission.BLUETOOTH_PRIVILEGED || permission == Manifest.permission.BLUETOOTH_CONNECT || permission == Manifest.permission.BLUETOOTH_SCAN) {
+                    activity.requestPermissions(bluetoothPermissions, REQUEST_PERMISSION_CODE)
+                }
+            }
+        }
+    }
+}

--- a/android/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
@@ -1,6 +1,5 @@
 package org.fossasia.badgemagic.ui
 
-import android.Manifest
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.DialogInterface
@@ -15,8 +14,6 @@ import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.appcompat.app.ActionBarDrawerToggle
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.FragmentTransaction
@@ -25,6 +22,7 @@ import org.fossasia.badgemagic.R
 import org.fossasia.badgemagic.core.android.log.Timber
 import org.fossasia.badgemagic.databinding.ActivityDrawerBinding
 import org.fossasia.badgemagic.extensions.setRotation
+import org.fossasia.badgemagic.others.BadgeMagicPermission
 import org.fossasia.badgemagic.ui.base.BaseActivity
 import org.fossasia.badgemagic.ui.base.BaseFragment
 import org.fossasia.badgemagic.ui.fragments.AboutFragment
@@ -58,7 +56,8 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        checkLocationPermission()
+        val permission = BadgeMagicPermission.instance
+        permission.checkPermissions(this, permission.ALL_PERMISSION)
 
         binding = ActivityDrawerBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -226,7 +225,8 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
 
     private fun prepareForScan() {
         if (isBleSupported()) {
-            checkManifestPermission()
+            val permission = BadgeMagicPermission.instance
+            permission.checkPermissions(this, permission.BLUETOOTH_PERMISSION)
         } else {
             Toast.makeText(this, "BLE is not supported", Toast.LENGTH_LONG).show()
             finish()
@@ -289,32 +289,10 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
             .commit()
     }
 
-    private fun checkManifestPermission() {
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED &&
-            ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_ADMIN) == PackageManager.PERMISSION_GRANTED &&
-            ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_PRIVILEGED) == PackageManager.PERMISSION_GRANTED &&
-            ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH) == PackageManager.PERMISSION_GRANTED &&
-            ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
-        ) {
-            Timber.i { "Coarse permission granted" }
-        } else {
-            ActivityCompat.requestPermissions(
-                this,
-                arrayOf(
-                    Manifest.permission.ACCESS_FINE_LOCATION,
-                    Manifest.permission.BLUETOOTH_ADMIN,
-                    Manifest.permission.BLUETOOTH_PRIVILEGED,
-                    Manifest.permission.BLUETOOTH
-                ),
-                REQUEST_PERMISSION_CODE
-            )
-        }
-    }
-
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
         when (requestCode) {
             REQUEST_PERMISSION_CODE -> {
-                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
+                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     Timber.d { "Required Permission Accepted" }
                 }
             }
@@ -381,36 +359,5 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
         val drawerLayout: DrawerLayout = findViewById(R.id.drawer_layout)
         drawerLayout.closeDrawer(GravityCompat.START)
         return true
-    }
-
-    private fun hasLocationPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            this, Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED
-    }
-    private fun checkLocationPermission() {
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED ||
-            ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED
-        ) {
-
-            // Show an explanation to the user why the permission is needed
-            if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.ACCESS_FINE_LOCATION) ||
-                ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.ACCESS_COARSE_LOCATION)
-            ) {
-
-                AlertDialog.Builder(this)
-                    .setTitle("Location Permission Needed")
-                    .setMessage("This app needs the Location permission to scan for nearby ble devices. Please grant the permission.")
-                    .setPositiveButton("OK") { _, _ ->
-                    }
-                    .create()
-                    .show()
-            } else {
-                ActivityCompat.requestPermissions(
-                    this, arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
-                    REQUEST_PERMISSION_CODE
-                )
-            }
-        }
     }
 }


### PR DESCRIPTION
Fixes #928 
Adds prominent disclosure dialogs for location and storage permissions. Cleans up the code a bit by migrating all permission checks to a separate kotlin class BadgeMagicPermission.kt.

## Changes: 
- android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt - Added a new kotlin class that handles all the permission checks.
- android/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt

## Screenshots for the change:
![WhatsApp Image 2024-05-22 at 3 41 10 PM](https://github.com/fossasia/badgemagic-android/assets/125425881/af2cac0c-b240-4366-846c-dfddee07a45a)
![WhatsApp Image 2024-05-22 at 3 41 11 PM](https://github.com/fossasia/badgemagic-android/assets/125425881/67be0990-a700-4e00-9972-bb5a0cc04d15)
Here, is a recording for the same:
https://www.youtube.com/shorts/cV6atqGElhw

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.