### PR TITLE
fix: Crash caused by missing permission on Android 12

### DIFF
--- a/android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt
@@ -16,9 +16,8 @@ class BadgeMagicPermission private constructor() {
     val allPermissions = arrayOf(
         Manifest.permission.WRITE_EXTERNAL_STORAGE,
         Manifest.permission.ACCESS_FINE_LOCATION,
-        Manifest.permission.BLUETOOTH,
-        Manifest.permission.BLUETOOTH_ADMIN,
-        Manifest.permission.BLUETOOTH_PRIVILEGED,
+        Manifest.permission.BLUETOOTH_SCAN,
+        Manifest.permission.BLUETOOTH_CONNECT,
     )
 
     val storagePermissions = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
@@ -26,9 +25,8 @@ class BadgeMagicPermission private constructor() {
     val locationPermissions = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
 
     val bluetoothPermissions = arrayOf(
-        Manifest.permission.BLUETOOTH,
-        Manifest.permission.BLUETOOTH_ADMIN,
-        Manifest.permission.BLUETOOTH_PRIVILEGED,
+        Manifest.permission.BLUETOOTH_CONNECT,
+        Manifest.permission.BLUETOOTH_SCAN,
     )
 
     val ALL_PERMISSION = 100


### PR DESCRIPTION
The crash appeared again since changing the target API to 33 as BLUETOOTH_CONNECT and BLUETOOTH_SCAN should required at runtime.

Fixes #909

Changes: Add BLUETOOTH_CONNECT and BLUETOOTH_SCAN to runtime permission request

Screenshots for the change:

![image](https://github.com/fossasia/badgemagic-android/assets/52123562/501d96d2-0bd0-4f54-8f49-cb98a3ab574a)
