### PR TITLE
fix: updates the language of the dialog and adds permission flags in the manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.fossasia.badgemagic">
 
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"/>
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
@@ -12,7 +13,7 @@
 	<uses-feature android:name="android.hardware.bluetooth" android:required="true"/>
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <uses-feature android:name="android.hardware.location.gps" />
 

--- a/android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt
@@ -71,7 +71,7 @@ class BadgeMagicPermission private constructor() {
                 if (permission == Manifest.permission.ACCESS_FINE_LOCATION) {
                     val builder = AlertDialog.Builder(activity)
                     builder.setTitle("Location Permission Disclosure")
-                    builder.setMessage("Badge Magic requires access to location data to enable the transfer of data to LED Badges via Bluetooth LE.")
+                    builder.setMessage("Badge Magic collects location data to enable the transfer of data to LED Badges via Bluetooth LE in the background.")
                     builder.setCancelable(false)
                     builder.setPositiveButton("ACCEPT") { _, _ ->
                         activity.requestPermissions(locationPermissions, REQUEST_PERMISSION_CODE)


### PR DESCRIPTION
Fixes #928 
Updates the language of the disclosure dialog in accordance with Google's documentation.
Adds permission flags in the manifest to assert that the app never derives location from bluetooth.

## Changes:
- android/src/main/AndroidManifest.xml
- android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt

## Screenshots for the change:
![Screenshot_20240523_122412](https://github.com/fossasia/badgemagic-android/assets/125425881/72b448e9-b527-4897-9700-e818a9a7ad20)


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.
