### PR TITLE
Overhaul file handling and sharing badges

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -12,9 +12,6 @@
 	<uses-feature android:name="android.hardware.bluetooth" android:required="true"/>
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-
     <application
         android:name=".BadgeMagicApp"
         android:allowBackup="true"

--- a/android/src/main/java/org/fossasia/badgemagic/database/StorageFilesService.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/database/StorageFilesService.kt
@@ -30,7 +30,7 @@ class StorageFilesService : KoinComponent {
         storageUtils.saveFile(filename, json)
     }
 
-    fun getAbsPath(fileName: String): String? = storageUtils.getAbsolutePathofFiles(fileName)
+    fun getAbsPath(fileName: String): String = storageUtils.getAbsolutePathofFiles(fileName)
 
     fun checkIfFilePresent(fileName: String): Boolean = storageUtils.checkIfFilePresent(fileName)
 }

--- a/android/src/main/java/org/fossasia/badgemagic/ui/fragments/SavedBadgesFragment.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/fragments/SavedBadgesFragment.kt
@@ -143,19 +143,20 @@ class SavedBadgesFragment : BaseFragment() {
 
     private fun transferItem(item: ConfigInfo) {
         val intentShareFile = Intent(Intent.ACTION_SEND)
-        intentShareFile.type = "text/*"
+        val fileUri = FileProvider.getUriForFile(
+            requireContext(),
+            getString(R.string.file_provider_authority),
+            File(viewModel.getAbsPath(item.fileName))
+        )
+        intentShareFile.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        intentShareFile.type = "text/plain"
+        intentShareFile.setDataAndType(fileUri, "text/plain")
         intentShareFile.putExtra(
             Intent.EXTRA_STREAM,
-            FileProvider.getUriForFile(
-                requireContext(),
-                getString(R.string.file_provider_authority),
-                File(
-                    viewModel.getAbsPath(item.fileName)
-                )
-            )
+            fileUri
         )
         intentShareFile.putExtra(Intent.EXTRA_SUBJECT, "Badge Magic Share: " + item.fileName)
-        intentShareFile.putExtra(Intent.EXTRA_TEXT, "Badge Magic Share: " + item.fileName)
+        intentShareFile.putExtra(Intent.EXTRA_TEXT, File(viewModel.getAbsPath(item.fileName)).readText())
 
         this.startActivity(Intent.createChooser(intentShareFile, item.fileName))
     }

--- a/android/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/fragments/TextArtFragment.kt
@@ -3,7 +3,6 @@ package org.fossasia.badgemagic.ui.fragments
 import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.content.DialogInterface
-import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
@@ -21,7 +20,6 @@ import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
-import androidx.core.app.ActivityCompat
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.tabs.TabLayout
@@ -61,7 +59,6 @@ import java.util.TimerTask
 class TextArtFragment : BaseFragment() {
     companion object {
         private const val SCAN_TIMEOUT_MS = 9500L
-        private const val REQUEST_PERMISSION_CODE = 10
         @JvmStatic
         fun newInstance() =
             TextArtFragment()
@@ -116,9 +113,7 @@ class TextArtFragment : BaseFragment() {
 
     private fun setupButton() = with(binding) {
         saveButton.setOnClickListener {
-            if (checkStoragePermission()) {
-                startSaveFile()
-            }
+            startSaveFile()
         }
 
         transferButton.setOnClickListener {
@@ -153,29 +148,6 @@ class TextArtFragment : BaseFragment() {
     private fun startSaveFile() {
         binding.textViewMainText.hideKeyboard()
         showSaveFileDialog()
-    }
-
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        when (requestCode) {
-            REQUEST_PERMISSION_CODE -> {
-                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    startSaveFile()
-                }
-            }
-            else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        }
-    }
-
-    private fun checkStoragePermission(): Boolean {
-        return if (ActivityCompat.checkSelfPermission(
-                requireContext(),
-                android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-            requestPermissions(arrayOf(android.Manifest.permission.WRITE_EXTERNAL_STORAGE), REQUEST_PERMISSION_CODE)
-            false
-        } else
-            true
     }
 
     private val textChangedListener = object : TextWatcher {

--- a/android/src/main/java/org/fossasia/badgemagic/viewmodels/FilesViewModel.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/viewmodels/FilesViewModel.kt
@@ -11,5 +11,5 @@ class FilesViewModel(
 
     fun deleteFile(fileName: String) = storageFilesService.deleteFile(fileName)
 
-    fun getAbsPath(fileName: String): String? = storageFilesService.getAbsPath(fileName)
+    fun getAbsPath(fileName: String): String = storageFilesService.getAbsPath(fileName)
 }

--- a/android/src/main/res/xml/file_provider_paths.xml
+++ b/android/src/main/res/xml/file_provider_paths.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-path
+    <external-files-path
         name="external_files" path="." />
+    <files-path
+        name="files"
+        path="." />
 </paths>


### PR DESCRIPTION
*_EXTERNAL_STORAGE is deprecated and non-functional in Android 13+. There really isn't any reason to use external storage for the badges and cliparts anyways. This commit changes Badge Magic to use app-internal internal storage that can be freely accessed without requiring permissions. This fixes badge saving on Android 13+.

Sharing badges has been slightly improved: Many apps don't read the EXTRA_STREAM property, even if a valid (and readable) URI is provided there. The EXTRA_TEXT property shouldn't contain a description, like was done before, but the actual text content of the file. This is now what badge sharing does, allowing text content of badges to be shared to many more apps. Additionally, the MIME type "text/*" doesn't really exist, so text/plain is used instead, though this could be changed to text/json.

Unfortunately, this change resets all saved cliparts and badges of the user. Since they have previously been saved in external storage, it should be feasible to import at least all the old badges. Once importing cliparts becomes possible, the first issue will be solved as well.