### PR TITLE
fix: BLE won't work on Android 11 and below

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
 	<uses-feature android:name="android.hardware.bluetooth" android:required="true"/>
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30"/>
+
     <application
         android:name=".BadgeMagicApp"
         android:allowBackup="true"

--- a/android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/others/BadgeMagicPermission.kt
@@ -16,11 +16,14 @@ class BadgeMagicPermission private constructor() {
 
     val allPermissions = arrayOf(
         Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        Manifest.permission.ACCESS_FINE_LOCATION,
         Manifest.permission.BLUETOOTH_SCAN,
         Manifest.permission.BLUETOOTH_CONNECT,
     )
 
     val storagePermissions = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+
+    val locationPermissions = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
 
     val bluetoothPermissions = arrayOf(
         Manifest.permission.BLUETOOTH_CONNECT,
@@ -29,6 +32,7 @@ class BadgeMagicPermission private constructor() {
 
     val ALL_PERMISSION = 100
     val STORAGE_PERMISSION = 101
+    val LOCATION_PERMISSION = 102
     val BLUETOOTH_PERMISSION = 103
 
     val listPermissionsNeeded = arrayListOf<String>()
@@ -49,6 +53,13 @@ class BadgeMagicPermission private constructor() {
                 }
             }
         }
+        if (mode == LOCATION_PERMISSION) {
+            for (permission in locationPermissions) {
+                if (ContextCompat.checkSelfPermission(activity, permission) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                    listPermissionsNeeded.add(permission)
+                }
+            }
+        }
         if (mode == BLUETOOTH_PERMISSION) {
             for (permission in bluetoothPermissions) {
                 if (ContextCompat.checkSelfPermission(activity, permission) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
@@ -58,7 +69,20 @@ class BadgeMagicPermission private constructor() {
         }
         if (listPermissionsNeeded.size > 0) {
             for (permission in listPermissionsNeeded) {
-                if (permission == Manifest.permission.WRITE_EXTERNAL_STORAGE) {
+                if (permission == Manifest.permission.ACCESS_FINE_LOCATION && android.os.Build.VERSION.SDK_INT <= 30) {
+                    AlertDialog.Builder(activity)
+                        .setIcon(ContextCompat.getDrawable(activity, R.drawable.ic_caution))
+                        .setTitle(activity.getString(R.string.location_required_title))
+                        .setMessage(activity.getString(R.string.location_required_message))
+                        .setPositiveButton("OK") { _, _ ->
+                            activity.requestPermissions(locationPermissions, REQUEST_PERMISSION_CODE)
+                        }
+                        .setNegativeButton("Cancel") { _, _ ->
+                            Toast.makeText(activity, activity.getString(R.string.location_canceled_warning), Toast.LENGTH_SHORT).show()
+                        }
+                        .create()
+                        .show()
+                } else if (permission == Manifest.permission.WRITE_EXTERNAL_STORAGE) {
                     AlertDialog.Builder(activity)
                         .setIcon(ContextCompat.getDrawable(activity, R.drawable.ic_caution))
                         .setTitle(activity.getString(R.string.storage_required_title))

--- a/android/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/ui/DrawerActivity.kt
@@ -1,5 +1,6 @@
 package org.fossasia.badgemagic.ui
 
+import android.Manifest
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.DialogInterface
@@ -224,7 +225,7 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
     private fun prepareForScan() {
         if (isBleSupported()) {
             val permission = BadgeMagicPermission.instance
-            permission.checkPermissions(this, permission.BLUETOOTH_PERMISSION)
+            permission.checkPermissions(this, permission.LOCATION_PERMISSION)
         } else {
             Toast.makeText(this, "BLE is not supported", Toast.LENGTH_LONG).show()
             finish()
@@ -292,6 +293,15 @@ class DrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedLi
             REQUEST_PERMISSION_CODE -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     Timber.d { "Required Permission Accepted" }
+                }
+                for (p in permissions) {
+                    if (
+                        p == Manifest.permission.ACCESS_FINE_LOCATION &&
+                        grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+                    ) {
+                        val permission = BadgeMagicPermission.instance
+                        permission.checkPermissions(this, permission.BLUETOOTH_PERMISSION)
+                    }
                 }
             }
             else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/android/src/main/java/org/fossasia/badgemagic/util/BluetoothAdapter.kt
+++ b/android/src/main/java/org/fossasia/badgemagic/util/BluetoothAdapter.kt
@@ -3,6 +3,9 @@ package org.fossasia.badgemagic.util
 import android.app.AlertDialog
 import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.content.Intent
+import android.location.LocationManager
+import android.provider.Settings
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import org.fossasia.badgemagic.R
@@ -12,7 +15,7 @@ class BluetoothAdapter(appContext: Context) {
     private val btAdapter = btManager.adapter!!
 
     fun isTurnedOn(context: Context): Boolean = when {
-        btAdapter.isEnabled -> true
+        btAdapter.isEnabled -> scanLocationPermissions(context)
         else -> {
             showAlertDialog(context)
             false
@@ -23,6 +26,22 @@ class BluetoothAdapter(appContext: Context) {
         if (btAdapter.disable()) {
             btAdapter.enable()
         }
+    }
+
+    private fun scanLocationPermissions(context: Context): Boolean {
+        val lm = context.getSystemService(Context.LOCATION_SERVICE)
+        if (lm is LocationManager) {
+            if (!lm.isProviderEnabled(LocationManager.GPS_PROVIDER) && android.os.Build.VERSION.SDK_INT <= 30) {
+                AlertDialog.Builder(context)
+                    .setMessage(R.string.no_gps_enabled)
+                    .setPositiveButton("OK") { _, _ -> context.startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)) }
+                    .setNegativeButton("Cancel", null)
+                    .show()
+                return false
+            }
+            return true
+        }
+        return false
     }
 
     private fun showAlertDialog(context: Context) {

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -93,6 +93,14 @@
     <string name="clipart_saved_success">ClipArt已成功保存</string>
     <string name="clipart_saved_error">保存剪贴画时出错</string>
     <string name="drawer_saved_cliparts">保存的教具</string>
+    <string name="no_gps_enabled">找不到GPS，请从设置中启用GPS</string>
+
+    <string name="location_required_title">需要位置许可</string>
+    <string name="location_required_message">
+		Badge Magic 会收集位置数据以启用蓝牙低功耗并连接到 LED 徽章并将数据传输到徽章，即使应用程序关闭或未使用也是如此。\n不会将任何位置数据传输到外部设备或我们的服务器。
+	</string>
+    <string name="location_canceled_warning">请允许位置权限。 蓝牙 LE 需要这个才能工作。</string>
+	
 
     <string name="storage_required_title">需要存储权限</string>
     <string name="storage_required_message">Badge Magic 需要访问存储空间才能保存和访问已保存的徽章/剪贴画</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -108,6 +108,18 @@
     <string name="clipart_saved_success">ClipArt Saved Successfully</string>
     <string name="clipart_saved_error">Error in saving Clipart</string>
     <string name="drawer_saved_cliparts">Saved Cliparts</string>
+    <string name="no_gps_enabled">No GPS Found, Please Enable GPS from Settings</string>
+	
+    <string name="location_required_title">Location Permission Required</string>
+    <string name="location_required_message">
+        Badge Magic uses location data to enable Bluetooth LE and to transfer
+        data to the badges. No location data is transferred to external devices
+        or our servers.
+	</string>
+    <string name="location_canceled_warning">
+        Please allow Location permissions.
+        Bluetooth LE requires this to work.
+    </string>
 
     <string name="storage_required_title">Storage Permission Required</string>
     <string name="storage_required_message">Badge Magic requires access to storage to save and access saved Badges/Cliparts.</string>


### PR DESCRIPTION
Fixes #957

Changes:
- revert c22c2432 (#936)
- only ask for Location and show Prominent Disclosure on Android 11 and below

Had been tested on Android 10.