### PR TITLE
chore: update gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/android/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the Dependabot configuration to include a daily update schedule for Gradle dependencies in the /android/ directory.

CI:
- Add a daily update schedule for Gradle dependencies in the /android/ directory to the Dependabot configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->