### PR TITLE
fix: widget overflow resolved

### DIFF
--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -68,27 +68,31 @@ class _DrawBadgeState extends State<DrawBadge> {
       title: 'BadgeMagic',
       body: Column(
         children: [
-          Container(
-            margin: EdgeInsets.symmetric(vertical: 20.h, horizontal: 20.w),
-            padding: EdgeInsets.all(10.dg),
-            height: 400.h,
-            width: 500.w,
-            decoration: BoxDecoration(
-              color: Colors.black,
-              border: Border.all(color: Colors.black),
-              borderRadius: BorderRadius.circular(10),
-            ),
-            child: BMBadge(
-              providerInit: (provider) => drawToggle = provider,
-              badgeGrid: widget.badgeGrid
-                  ?.map((e) => e.map((e) => e == 1).toList())
-                  .toList(),
+          Expanded(
+            flex: 1,
+            child: Container(
+              margin: EdgeInsets.symmetric(vertical: 20.h, horizontal: 10.w),
+              padding: EdgeInsets.all(10.dg),
+              height: 400.h,
+              width: 500.w,
+              decoration: BoxDecoration(
+                color: Colors.black,
+                border: Border.all(color: Colors.black),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: BMBadge(
+                providerInit: (provider) => drawToggle = provider,
+                badgeGrid: widget.badgeGrid
+                    ?.map((e) => e.map((e) => e == 1).toList())
+                    .toList(),
+              ),
             ),
           ),
           SizedBox(
             height: 55.h,
           ),
           Row(
+            mainAxisAlignment: MainAxisAlignment.center,
             children: [
               TextButton(
                 onPressed: () {

--- a/lib/view/widgets/save_badge_dialog.dart
+++ b/lib/view/widgets/save_badge_dialog.dart
@@ -41,15 +41,18 @@ class SaveBadgeDialog extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            const Text(
-              'Save Badge',
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 18,
+            Expanded(
+              flex: 1,
+              child: const Text(
+                'Save Badge',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
               ),
             ),
-            const SizedBox(
-                height: 10), // Space between title and file name text
+            // const SizedBox(
+            //     height: 10), // Space between title and file name text
             const Text(
               'File Name',
               style: TextStyle(


### PR DESCRIPTION
Fix #1066 
Please find attached screenshots to verify
![image](https://github.com/user-attachments/assets/6f35a929-b04e-4143-afa0-98db82eaff25)
![image](https://github.com/user-attachments/assets/e00b4870-bab9-4f6c-acff-b2b057c2ba5f)

## Summary by Sourcery

Bug Fixes:
- Resolve widget overflow issue by adjusting layout with Expanded widgets in draw_badge_screen.dart and save_badge_dialog.dart.