### PR TITLE
fix: delete symbol issue fixed

### DIFF
--- a/lib/providers/imageprovider.dart
+++ b/lib/providers/imageprovider.dart
@@ -165,10 +165,6 @@ class InlineImageProvider extends ChangeNotifier {
     String text = message.text;
     String before = text.substring(0, start);
     String after = text.substring(end);
-    print("before: " + before);
-    print('\n');
-    print("after: " + after);
-    print('\n');
     message.text = before + after;
     message.selection = TextSelection.fromPosition(
       TextPosition(offset: 0),

--- a/lib/providers/imageprovider.dart
+++ b/lib/providers/imageprovider.dart
@@ -153,4 +153,59 @@ class InlineImageProvider extends ChangeNotifier {
       }
     }
   }
+
+  void moveCursorToEnd() {
+    message.selection = TextSelection.fromPosition(
+      TextPosition(offset: message.text.length),
+    );
+    notifyListeners();
+  }
+
+  void deleteInlineImage(int start, int end) {
+    String text = message.text;
+    String before = text.substring(0, start);
+    String after = text.substring(end);
+    print("before: " + before);
+    print('\n');
+    print("after: " + after);
+    print('\n');
+    message.text = before + after;
+    message.selection = TextSelection.fromPosition(
+      TextPosition(offset: 0),
+    );
+    notifyListeners();
+  }
+
+  void handleDelete() {
+    int start = message.selection.baseOffset;
+    int end = message.selection.extentOffset;
+    if (start == end) {
+      // Handle backspace
+      if (start > 0) {
+        String text = message.text;
+        int deleteStart = start - 1;
+        int deleteEnd = start;
+        // Check if we are deleting a placeholder
+        if (text.substring(deleteStart, deleteEnd) == '>') {
+          int placeholderStart = text.lastIndexOf('<<', deleteStart);
+          if (placeholderStart != -1) {
+            deleteStart = placeholderStart;
+          }
+        }
+        deleteInlineImage(deleteStart, deleteEnd);
+      }
+    } else {
+      // String text = message.text;
+      // int deleteStart = start - 1;
+      // int deleteEnd = start;
+      // // Check if we are deleting a placeholder
+      // if (text.substring(deleteStart, deleteEnd) == '>') {
+      //   int placeholderStart = text.lastIndexOf('<<', deleteStart);
+      //   if (placeholderStart != -1) {
+      //     deleteStart = placeholderStart;
+      //   }
+      // }
+      // deleteInlineImage(deleteStart, deleteEnd);
+    }
+  }
 }

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -132,26 +132,35 @@ class _HomeScreenState extends State<HomeScreen>
                             color: Colors.white,
                             borderRadius: BorderRadius.circular(10.r),
                             elevation: 4,
-                            child: ExtendedTextField(
-                              onChanged: (value) {},
-                              controller: inlineImageProvider.getController(),
-                              specialTextSpanBuilder:
-                                  MySpecialTextSpanBuilder(),
-                              decoration: InputDecoration(
-                                border: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(10.r),
-                                ),
-                                prefixIcon: IconButton(
-                                  onPressed: () {
-                                    setState(() {
-                                      isPrefixIconClicked =
-                                          !isPrefixIconClicked;
-                                    });
-                                  },
-                                  icon: const Icon(Icons.tag_faces_outlined),
-                                ),
-                                focusedBorder: const OutlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.red),
+                            child: KeyboardListener(
+                              focusNode: FocusNode(),
+                              autofocus: true,
+                              onKeyEvent: (value) => {
+                                if (value.logicalKey ==
+                                    LogicalKeyboardKey.backspace)
+                                  {inlineImageProvider.handleDelete()}
+                              },
+                              child: ExtendedTextField(
+                                onChanged: (value) {},
+                                controller: inlineImageProvider.getController(),
+                                specialTextSpanBuilder:
+                                    MySpecialTextSpanBuilder(),
+                                decoration: InputDecoration(
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10.r),
+                                  ),
+                                  prefixIcon: IconButton(
+                                    onPressed: () {
+                                      setState(() {
+                                        isPrefixIconClicked =
+                                            !isPrefixIconClicked;
+                                      });
+                                    },
+                                    icon: const Icon(Icons.tag_faces_outlined),
+                                  ),
+                                  focusedBorder: const OutlineInputBorder(
+                                    borderSide: BorderSide(color: Colors.red),
+                                  ),
                                 ),
                               ),
                             ),


### PR DESCRIPTION
fix #1068 
Deleting symbols from between issue resolved now we can delete symbols from between the text also.
Please find the video below to verify

https://github.com/user-attachments/assets/ba08ad22-f9d3-4cc2-bc36-1a71a7ba0f18

## Summary by Sourcery

Fix the issue with deleting symbols from between text in the inline image provider and enhance the functionality by adding a method to move the cursor to the end of the text.

Bug Fixes:
- Resolve issue with deleting symbols from between text in the inline image provider.

Enhancements:
- Add a method to move the cursor to the end of the text in the inline image provider.