### PR TITLE
chore: release to open testing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -149,10 +149,10 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       
-      - name: Push app in closed testing track
+      - name: Push app in open testing track
         if: ${{ github.repository == 'fossasia/badgemagic-android' }}
         run: |
-          bundle exec fastlane uploadToClosedTesting
+          bundle exec fastlane uploadToOpenTesting
           if [[ $? -ne 0 ]]; then
               exit 1
           fi


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update CI workflow to push app to open testing track instead of closed testing track.