### PR TITLE
fix: animation and Effects layouts

### DIFF
--- a/lib/view/widgets/animation_container.dart
+++ b/lib/view/widgets/animation_container.dart
@@ -50,9 +50,11 @@ class _AniContainerState extends State<AniContainer> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Image.asset(
-                widget.animation,
-                height: 30.h,
+              Flexible(
+                child: Image.asset(
+                  widget.animation,
+                  fit: BoxFit.contain,
+                ),
               ),
               Text(
                 widget.animationName,

--- a/lib/view/widgets/effects_container.dart
+++ b/lib/view/widgets/effects_container.dart
@@ -59,9 +59,11 @@ class _EffectContainerState extends State<EffectContainer> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Image.asset(
-                widget.effect,
-                height: 60.h,
+              Flexible(
+                child: Image.asset(
+                  widget.effect,
+                  fit: BoxFit.contain,
+                ),
               ),
               Text(widget.effectName),
             ],


### PR DESCRIPTION
Fixes #1097 
Makes the layouts responsive by ensuring that the images always fit in the _Containers_, and hence, overflow doesn't happen on any screen size.

## Screenshots / Recordings  
Here are screenshots obtained from the same device after the fix :-

<img src="https://github.com/user-attachments/assets/9c930aee-420b-45a1-b74a-e9c42a42999f" width = "400" height = "800"/>
<img src="https://github.com/user-attachments/assets/e5df6e94-a770-4b42-a32a-cb1ae222220e" width = "400" height = "800"/>

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Fix layout issues in Animation and Effects containers by ensuring images fit within their containers and improve responsiveness using Flexible widgets and BoxFit.contain.

Bug Fixes:
- Fix layout issues in Animation and Effects containers by ensuring images fit within their containers, preventing overflow on various screen sizes.

Enhancements:
- Improve responsiveness of Animation and Effects layouts by using Flexible widgets and BoxFit.contain for images.