### PR TITLE
chore: enable version updates for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
     directory: "/android/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directories:
+    - "/.github/workflows"
+    - "/.github/actions/android"
+    - "/.github/actions/common"
+    - "/.github/actions/ios"
+    - "/.github/actions/screenshot-android"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Configure _dependabot_ to enable version updates for the _Github Actions_ package ecosystem.

## Summary by Sourcery

Chores:
- Enable version updates for the Github Actions package ecosystem using dependabot.