### PR TITLE
fix: inlineimagecontroller  now has a validation check

### DIFF
--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -47,6 +47,7 @@ class _HomeScreenState extends State<HomeScreen>
   final TextEditingController inlineimagecontroller =
       GetIt.instance.get<InlineImageProvider>().getController();
   bool isDialInteracting = false;
+  String errorVal = "";
 
   @override
   void initState() {
@@ -172,6 +173,8 @@ class _HomeScreenState extends State<HomeScreen>
                               controller: inlineimagecontroller,
                               specialTextSpanBuilder: ImageBuilder(),
                               decoration: InputDecoration(
+                                hintText: errorVal,
+                                hintStyle: TextStyle(color: Colors.red),
                                 border: OutlineInputBorder(
                                   borderRadius: BorderRadius.circular(10.r),
                                 ),
@@ -262,21 +265,31 @@ class _HomeScreenState extends State<HomeScreen>
                                     onTap: () {
                                       logger.i(
                                           'Save button clicked, showing dialog : ${animationProvider.isEffectActive(FlashEffect())}');
-                                      showDialog(
-                                          context: this.context,
-                                          builder: (context) {
-                                            return SaveBadgeDialog(
-                                              speed: speedDialProvider,
-                                              animationProvider:
-                                                  animationProvider,
-                                              textController:
-                                                  inlineImageProvider
-                                                      .getController(),
-                                              isInverse: animationProvider
-                                                  .isEffectActive(
-                                                      InvertLEDEffect()),
-                                            );
-                                          });
+                                      inlineimagecontroller.text == ""
+                                          ? setState(() {
+                                              errorVal =
+                                                  "Please fill out this field";
+                                            })
+                                          : {
+                                              setState(() {
+                                                errorVal = "";
+                                              }),
+                                              showDialog(
+                                                  context: this.context,
+                                                  builder: (context) {
+                                                    return SaveBadgeDialog(
+                                                      speed: speedDialProvider,
+                                                      animationProvider:
+                                                          animationProvider,
+                                                      textController:
+                                                          inlineImageProvider
+                                                              .getController(),
+                                                      isInverse: animationProvider
+                                                          .isEffectActive(
+                                                              InvertLEDEffect()),
+                                                    );
+                                                  })
+                                            };
                                     },
                                     child: Container(
                                       padding: EdgeInsets.symmetric(


### PR DESCRIPTION
This PR solves a small edge case where the Value of  ```inlineimagecontroller``` used by ```ExtendedTextField``` is null. Ideally it should have some sort of error checking mechanism else when it gets saved and is played from the ```SavedBadges``` section, it throws the error: 

```
======== Exception caught by gesture ===============================================================
The following ArgumentError was thrown while handling a gesture:
Invalid argument(s): Invalid hex string:

When the exception was thrown, this was the stack: 
#0      hexStringToBool (package:badgemagic/bademagic_module/utils/byte_array_utils.dart:35:5)
#1      SavedBadgeProvider.savedBadgeAnimation (package:badgemagic/providers/saved_badge_provider.dart:101:36)
#2      SaveBadgeCard.build.<anonymous closure>.<anonymous closure> (package:badgemagic/view/widgets/save_badge_card.dart:84:34)
#3      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1170:21)
#4      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:351:24)
#5      TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:656:11)
#6      BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:313:5)
#7      BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:283:7)
#8      GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:169:27)
#9      GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:505:20)
#10     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:481:22)
#11     RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:450:11)
#12     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:426:7)
#13     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:389:5)
#14     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:336:7)
#15     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:305:9)
#16     _invoke1 (dart:ui/hooks.dart:328:13)
#17     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:442:7)
#18     _dispatchPointerDataPacket (dart:ui/hooks.dart:262:31)
Handler: "onTap"
Recognizer: TapGestureRecognizer#5a747
  debugOwner: GestureDetector
  state: ready
  won arena
  finalPosition: Offset(140.7, 397.5)
  finalLocalPosition: Offset(5.7, 16.7)
  button: 1
  sent tap down
```

THE CHANGES IN THIS PR FIX THIS

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where saving a badge with an empty inline image value would throw an error.