### PR TITLE
feat: validate Data and Message models on construction

### DIFF
--- a/lib/bademagic_module/models/data.dart
+++ b/lib/bademagic_module/models/data.dart
@@ -11,9 +11,23 @@ class Data {
 
   // Convert JSON to Data object
   factory Data.fromJson(Map<String, dynamic> json) {
+    if (!json.containsKey('messages')) {
+      throw Exception('Invalid JSON: Missing "messages" key');
+    }
+
+    if (json['messages'] is! List) {
+      throw Exception('Invalid JSON: "messages" must be a list');
+    }
+
+    if (json['messages'].isEmpty) {
+      throw Exception('Invalid JSON: "messages" list is empty');
+    }
+
     var messagesFromJson = json['messages'] as List;
+
     List<Message> messageList =
         messagesFromJson.map((message) => Message.fromJson(message)).toList();
+
     return Data(messages: messageList);
   }
 }

--- a/lib/bademagic_module/models/data.dart
+++ b/lib/bademagic_module/models/data.dart
@@ -25,6 +25,10 @@ class Data {
 
     var messagesFromJson = json['messages'] as List;
 
+    if (messagesFromJson.any((message) => message == null)) {
+      throw Exception('Invalid JSON: "messages" list contains null values');
+    }
+
     List<Message> messageList =
         messagesFromJson.map((message) => Message.fromJson(message)).toList();
 

--- a/lib/bademagic_module/models/messages.dart
+++ b/lib/bademagic_module/models/messages.dart
@@ -27,10 +27,6 @@ class Message {
 
   // Convert JSON to Message object
   factory Message.fromJson(Map<String, dynamic> json) {
-    if (json is! Map) {
-      throw Exception('Invalid JSON: "messages" must contain a map');
-    }
-
     if (!json.containsKey('text')) {
       throw Exception('Invalid JSON: Message missing "text" key');
     }
@@ -49,8 +45,8 @@ class Message {
 
     return Message(
       text: List<String>.from(json['text']),
-      flash: json['flash'] as bool,
-      marquee: json['marquee'] as bool,
+      flash: (json['flash'] as bool?) ?? false,
+      marquee: (json['marquee'] as bool?) ?? false,
       speed: Speed.fromHex(
           json['speed'] as String), // Using helper method for safety
       mode: Mode.fromHex(

--- a/lib/bademagic_module/models/messages.dart
+++ b/lib/bademagic_module/models/messages.dart
@@ -43,8 +43,13 @@ class Message {
       throw Exception('Invalid JSON: "text" must be a list');
     }
 
+    final textList = json['text'] as List;
+    if (textList.any((element) => element == null)) {
+      throw Exception('Invalid JSON: "text" list cannot contain null elements');
+    }
+
     return Message(
-      text: List<String>.from(json['text']),
+      text: List<String>.from(textList),
       flash: (json['flash'] as bool?) ?? false,
       marquee: (json['marquee'] as bool?) ?? false,
       speed: Speed.fromHex(

--- a/lib/bademagic_module/models/messages.dart
+++ b/lib/bademagic_module/models/messages.dart
@@ -27,6 +27,26 @@ class Message {
 
   // Convert JSON to Message object
   factory Message.fromJson(Map<String, dynamic> json) {
+    if (json is! Map) {
+      throw Exception('Invalid JSON: "messages" must contain a map');
+    }
+
+    if (!json.containsKey('text')) {
+      throw Exception('Invalid JSON: Message missing "text" key');
+    }
+
+    if (!json.containsKey('speed')) {
+      throw Exception('Invalid JSON: Message missing "speed" key');
+    }
+
+    if (!json.containsKey('mode')) {
+      throw Exception('Invalid JSON: Message missing "mode" key');
+    }
+
+    if (json['text'] is! List) {
+      throw Exception('Invalid JSON: "text" must be a list');
+    }
+
     return Message(
       text: List<String>.from(json['text']),
       flash: json['flash'] as bool,


### PR DESCRIPTION
This PR implements validation of `Data` and `Message` inputs and sets sane defaults for missing values.

## Summary by Sourcery

Implement validation for `Data` and `Message` models during construction, setting default values for missing fields.

New Features:
- Validate `Data` and `Message` model inputs upon creation.

Tests:
- No tests were added in this change, but existing tests now cover the validation logic.