### PR TITLE
feat: enable convertBitmapToLEDHex to trim or keep empty columns

### DIFF
--- a/lib/bademagic_module/utils/converters.dart
+++ b/lib/bademagic_module/utils/converters.dart
@@ -52,8 +52,7 @@ class Converters {
 
   //function to convert the bitmap to the LED hex format
   //it takes the 2D list of pixels and converts it to the LED hex format
-  static List<String> convertBitmapToLEDHex(
-      List<List<int>> image, bool isDrawn) {
+  static List<String> convertBitmapToLEDHex(List<List<int>> image, bool trim) {
     // Determine the height and width of the image
     int height = image.length;
     int width = image.isNotEmpty ? image[0].length : 0;
@@ -67,7 +66,7 @@ class Converters {
       for (int i = 0; i < height; i++) {
         sum += image[i][j]; // Sum up pixel values in each column
       }
-      if (sum == 0) {
+      if (sum == 0 && trim) {
         // If column sum is zero, mark all pixels in that column as -1
         for (int i = 0; i < height; i++) {
           image[i][j] = -1;
@@ -86,7 +85,7 @@ class Converters {
         sum += image[i]
             [j]; // Sum up pixel values in each column (from right to left)
       }
-      if (sum == 0) {
+      if (sum == 0 && trim) {
         // If column sum is zero, mark all pixels in that column as -1
         for (int i = 0; i < height; i++) {
           image[i][j] = -1;
@@ -176,6 +175,6 @@ class Converters {
       hexArray[i].add(1);
     }
 
-    return convertBitmapToLEDHex(hexArray, false);
+    return convertBitmapToLEDHex(hexArray, true);
   }
 }

--- a/lib/bademagic_module/utils/image_utils.dart
+++ b/lib/bademagic_module/utils/image_utils.dart
@@ -221,6 +221,6 @@ class ImageUtils {
         }
       }
     }
-    return Converters.convertBitmapToLEDHex(pixelArray, false);
+    return Converters.convertBitmapToLEDHex(pixelArray, true);
   }
 }

--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -145,7 +145,7 @@ class _DrawBadgeState extends State<DrawBadge> {
                       .map((e) => e.map((e) => e ? 1 : 0).toList())
                       .toList();
                   List<String> hexString =
-                      Converters.convertBitmapToLEDHex(badgeGrid, false);
+                      Converters.convertBitmapToLEDHex(badgeGrid, true);
                   widget.isSavedCard!
                       ? fileHelper.updateBadgeText(
                           widget.filename!,

--- a/test/converters_test.dart
+++ b/test/converters_test.dart
@@ -25,7 +25,7 @@ void main() {
       [0, 1]
     ];
 
-    List<String> result = Converters.convertBitmapToLEDHex(image, false);
+    List<String> result = Converters.convertBitmapToLEDHex(image, true);
 
     expect(result, ["1008"]);
   });


### PR DESCRIPTION
This commit renames the previously unused `isDrawn` parameter to `trim`
and uses it to decide whether empty columns should be removed or not.

## Summary by Sourcery

New Features:
- Added a `trim` parameter to `convertBitmapToLEDHex` to control whether empty columns are removed during conversion.