### PR TITLE
chore: switch Dev Container to use prebuilt image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
-  // "image": "ghcr.io/fossasia/flutter-devcontainer:latest",
+  "image": "ghcr.io/fossasia/badgemagic-app/flutter-devcontainer:latest",
   // Or build locally
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
+  // "build": {
+  //   "dockerfile": "Dockerfile"
+  // },
   "runArgs": [
     "--add-host",
     "host.docker.internal:host-gateway",


### PR DESCRIPTION
## Summary by Sourcery

Set up a Dev Container with pre-built image for a streamlined development environment. This includes installing Flutter and Android SDK, configuring ADB access, and setting up a scheduled build for the Dev Container image.

Build:
- Create a Dockerfile to build a Dev Container image with Flutter and Android SDK pre-installed.

CI:
- Add a weekly scheduled workflow to build and push the Dev Container image to the GitHub Container Registry.

Documentation:
- Document how to use the Dev Container, including connecting via ADB.

## Summary by Sourcery

Switch the Dev Container to use a pre-built image.

Build:
- Build and push a pre-built Dev Container image to a container registry on a weekly schedule.

CI:
- Add a scheduled workflow to build the Dev Container weekly.

Documentation:
- Document how to use the Dev Container with ADB.