### PR TITLE
chore: configure Fastfile to add lane to promote to Production

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -6,4 +6,11 @@ platform :android do
     lane :uploadToClosedTesting do
         upload_to_play_store(track: "alpha",aab:"../build/app/outputs/bundle/release/app-release.aab")
     end
+    lane :promoteToProduction do | options |
+        if options[:version_code]
+          supply(track: "beta",track_promote_to: "production",skip_upload_apk: true, version_code: options[:version_code])
+        else
+          UI.user_error!("You must provide a version_code option when promoting a version to production.")
+        end
+    end
 end


### PR DESCRIPTION
Adds a lane to push the APK with the supplied _versionCode_ to production, in our _fastlane-android_ branch.

## Summary by Sourcery

Deployment:
- Promote a specific version code to production via supply.