### PR TITLE
chore: fix push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,7 @@ on:
     branches: ["flutter_app"]
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ANDROID_EMULATOR_API: 34
   ANDROID_EMULATOR_ARCH: x86_64
 


### PR DESCRIPTION
Fixes the _push_ workflow by adding the GH token in the environment.

## Summary by Sourcery

CI:
- Set the GITHUB_TOKEN environment variable to the value of the GITHUB_TOKEN secret.