### PR TITLE
chore: fix action to update draft releases

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -191,6 +191,9 @@ jobs:
     needs: [common, android, ios]
     runs-on: ubuntu-latest
     steps:
+      - name: Download repository
+        uses: actions/checkout@v3
+
       - name: Run Release Drafter
         id: run-release-drafter
         uses: release-drafter/release-drafter@v6


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a step to download the repository using actions/checkout@v3 in the GitHub Actions workflow.