### PR TITLE
chore: setup release infrastructure

### DIFF
--- a/.github/actions/screenshot-android/action.yml
+++ b/.github/actions/screenshot-android/action.yml
@@ -65,7 +65,26 @@ runs:
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: |
-          flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d emulator
+          DEVICE_NAME="Pixel 6" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d emulator
+
+    - name: Update Fastlane Metadata
+      if: ${{ github.event_name != 'pull_request' }}
+      shell: bash
+      run: |
+        cd ./android
+        git clone --branch=fastlane-android --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+        cd fastlane
+        
+        rm -rf metadata/android/en-US/images/phoneScreenshots/*
+        cp -r ../../screenshots/. metadata/android/en-US/images/phoneScreenshots/
+        
+        # Force push to fastlane branch
+        git checkout --orphan temporary
+        git add --all .
+        git commit -am "[Auto] Update screenshots for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
+        git branch -D fastlane-android
+        git branch -m fastlane-android
+        git push --force origin fastlane-android
 
     - name: Upload Screenshots
       uses: actions/upload-artifact@v4

--- a/.github/actions/screenshot-ios/action.yml
+++ b/.github/actions/screenshot-ios/action.yml
@@ -40,12 +40,31 @@ runs:
     - name: Capture iPhone Screenshots
       shell: bash
       run: |
-        flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPHONE_DEVICE_MODEL }}"
+        DEVICE_NAME="${{ inputs.IPHONE_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPHONE_DEVICE_MODEL }}"
 
     - name: Capture iPad Screenshots
       shell: bash
       run: |
-        flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPAD_DEVICE_MODEL }}"
+        DEVICE_NAME="${{ inputs.IPAD_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPAD_DEVICE_MODEL }}"
+
+    - name: Update Fastlane Metadata
+      if: ${{ github.event_name != 'pull_request' }}
+      shell: bash
+      run: |
+        cd ./iOS
+        git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+        cd fastlane
+        
+        rm -rf screenshots/*
+        cp -r ../../screenshots/. screenshots/
+        
+        # Force push to fastlane branch
+        git checkout --orphan temporary
+        git add --all .
+        git commit -am "[Auto] Update screenshots for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
+        git branch -D fastlane-ios
+        git branch -m fastlane-ios
+        git push --force origin fastlane-ios
 
     - name: Upload Screenshots
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,21 +2,35 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  ANDROID_EMULATOR_API: 34
-  ANDROID_EMULATOR_ARCH: x86_64
 
 jobs:
   release:
+    name: Release
     if: ${{ github.repository == 'fossasia/badgemagic-app' }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Download repository
         uses: actions/checkout@v4
+
+      - name: Prepare Secrets (Android)
+        env:
+          ENCRYPTED_F10B5E0E5262_IV: ${{ secrets.ENCRYPTED_F10B5E0E5262_IV }}
+          ENCRYPTED_F10B5E0E5262_KEY: ${{ secrets.ENCRYPTED_F10B5E0E5262_KEY }}
+        run: |
+          bash scripts/prep-android-key.sh
+
+      - name: Prepare Secrets (iOS)
+        if: ${{ github.repository == 'fossasia/badgemagic-app' }}
+        env:
+          ENCRYPTED_IOS_IV: ${{ secrets.ENCRYPTED_IOS_IV }}
+          ENCRYPTED_IOS_KEY: ${{ secrets.ENCRYPTED_IOS_KEY }}
+        run: |
+          bash scripts/prep-ios-key.sh
 
       - name: Download Assets
         id: download-assets
@@ -28,13 +42,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Android Screenshot Workflow
-        uses: ./.github/actions/screenshot-android
-        with:
-          ANDROID_EMULATOR_API: ${{ env.ANDROID_EMULATOR_API }}
-          ANDROID_EMULATOR_ARCH: ${{ env.ANDROID_EMULATOR_ARCH }}
-
-      - name: Update Fastlane Metadata
+      - name: Update Fastlane Metadata (Android)
         run: |
           cd ./android
           git clone --branch=fastlane-android --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
@@ -42,20 +50,42 @@ jobs:
           
           echo "${{ github.event.release.body }}" > metadata/android/en-US/changelogs/${{ steps.download-assets.outputs.VERSION_CODE }}.txt
           
-          rm -rf metadata/android/en-US/images/phoneScreenshots/*
-          cp -r ../../screenshots/. metadata/android/en-US/images/phoneScreenshots/
-          
           # Force push to fastlane branch
           git checkout --orphan temporary
           git add --all .
-          git commit -am "[Auto] Update metadata for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
+          git commit -am "[Auto] Update changelogs for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
           git branch -D fastlane-android
           git branch -m fastlane-android
           git push --force origin fastlane-android
 
-      - name: Push version to production
+      - name: Push version to production (Android)
         run: |
+          cd ./android
           fastlane promoteToProduction version_code:${{ steps.download-assets.outputs.VERSION_CODE }}
           if [[ $? -ne 0 ]]; then
               exit 1
           fi
+
+      - name: Update Fastlane Metadata (iOS)
+        run: |
+          cd ./iOS
+          git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+          cd fastlane
+          
+          echo "${{ github.event.release.body }}" > metadata/en-US/release_notes.txt
+          
+          # Force push to fastlane branch
+          git checkout --orphan temporary
+          git add --all .
+          git commit -am "[Auto] Update changelogs for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
+          git branch -D fastlane-ios
+          git branch -m fastlane-ios
+          git push --force origin fastlane-ios
+
+      - name: Push version to production (iOS)
+        run: |
+          cd ./iOS
+          fastlane promoteToProduction build_number:${{ steps.download-assets.outputs.VERSION_CODE }}
+          if [[ $? -ne 0 ]]; then
+              exit 1
+          fi    

--- a/README.md
+++ b/README.md
@@ -37,11 +37,20 @@ There are a number of devices with Bluetooth on the market. As far as we can tel
 
 ## Screenshots
 
-| <!-- -->    | <!-- -->    | <!-- -->    |
-|-------------|-------------|-------------|
-| <img src="./docs/images/screen-1.jpg" width="288" /> <img src="./docs/images/screen-1-hard.png" width="288" /> | <img src="./docs/images/screen-2.jpg" width="288" /> <img src="./docs/images/screen-2-hard.png" width="288" /> | <img src="./docs/images/screen-3.jpg" width="288" /> <img src="./docs/images/screen-3-hard.png" width="288" /> |
-| <!-- -->    | <!-- -->    | <!-- -->    |
-| <img src="./docs/images/screen-4.jpg" width="288" /> <img src="./docs/images/screen-4-hard.png" width="288" /> | <img src="./docs/images/screen-5.jpg" width="288" /> <img src="./docs/images/screen-5-hard.png" width="288" /> | <img src="./docs/images/screen-6.jpg" width="288" /> <img src="./docs/images/screen-6-hard.png" width="288" /> |
+<table>
+  <tr>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-home_screen.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-text_badge.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-emoji_badge.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-inverted_emoji_badge.png" width="1080"/></td>
+  </tr>
+  <tr>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-saved_badges.png" width="1080"/></td>
+    <td colspan="3">
+      <img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-draw_badge.png" width="2146"/>
+    </td>
+  </tr>
+</table>
 
 ## Reverse-Engineering Bluetooth LE Devices
 

--- a/test_integration/screenshots.dart
+++ b/test_integration/screenshots.dart
@@ -29,7 +29,11 @@ void main() async {
       final drawBadgeScreenTitle = find.byKey(const ValueKey(drawBadgeScreen));
 
       await pumpUntilFound(tester, homeScreenTitle);
-      await binding.takeScreenshot('01');
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+      await binding.takeScreenshot('home_screen');
 
       final animationTabText = find.text('Animation');
       await tester.tap(animationTabText);
@@ -54,7 +58,7 @@ void main() async {
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
-      await binding.takeScreenshot('02');
+      await binding.takeScreenshot('text_badge');
 
       await tester.tap(inputField);
       await tester.pumpAndSettle();
@@ -89,7 +93,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('03');
+      await binding.takeScreenshot('emoji_badge');
 
       final invertEffectContainer = find.text('Invert');
       await tester.tap(invertEffectContainer);
@@ -97,7 +101,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('04');
+      await binding.takeScreenshot('inverted_emoji_badge');
 
       await tester.tap(invertEffectContainer);
       await tester.pumpAndSettle();
@@ -114,7 +118,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('05');
+      await binding.takeScreenshot('saved_badges');
 
       state = tester.firstState(find.byType(Scaffold));
       state.openDrawer();
@@ -126,7 +130,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('06');
+      await binding.takeScreenshot('draw_badge');
     });
   });
 }

--- a/test_integration/test_driver.dart
+++ b/test_integration/test_driver.dart
@@ -4,11 +4,12 @@ import 'dart:io';
 import 'package:integration_test/integration_test_driver_extended.dart';
 
 Future<void> main() async {
+  final deviceName = Platform.environment['DEVICE_NAME'] ?? 'unknown_device';
+  final formattedDeviceName = deviceName.replaceAll(RegExp(r'\s+'), '_');
   await integrationDriver(
     onScreenshot: (String screenshotName, List<int> screenshotBytes,
         [Map<String, Object?>? args]) async {
-      final timeStamp = DateTime.now().millisecondsSinceEpoch.toString();
-      final filePath = 'screenshots/$screenshotName-$timeStamp.png';
+      final filePath = 'screenshots/$formattedDeviceName-$screenshotName.png';
       print('Writing screenshot to $filePath');
 
       final File image = await File(filePath).create(recursive: true);


### PR DESCRIPTION
Sets up a release infrastructure for our repository.

1.  Every _push_ triggers the _screenshot_ workflows which then update the _fastlane_ metadata with the latest screenshots.
2. Every _release_ promotes a given build from testing to production for both _Android_ and _iOS_, with the body of the release as the changelog.
3. All the screenshots in _README_ now point to the latest ones always present in the _fastlane_ branches.

## Summary by Sourcery

Set up release infrastructure for Android and iOS.  Update screenshots in the README to always point to the latest screenshots stored in the fastlane branches.  On every release, promote the given build from testing to production and use the release body as the changelog.

CI:
- Automate the screenshot workflow to update Fastlane metadata and screenshots on every push, except for pull requests.

Deployment:
- Promote releases to production for Android and iOS using Fastlane.

Documentation:
- Update README screenshots to use the latest screenshots from the fastlane branches.