### PR TITLE
fix: commit messages for screenshot workflows

### DIFF
--- a/.github/actions/screenshot-android/action.yml
+++ b/.github/actions/screenshot-android/action.yml
@@ -84,7 +84,7 @@ runs:
         # Force push to fastlane branch
         git checkout --orphan temporary
         git add --all .
-        git commit -am "[Auto] Update screenshots for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
+        git commit -am "[Auto] Update screenshots ($(date +%Y-%m-%d.%H:%M:%S))"
         git branch -D fastlane-android
         git branch -m fastlane-android
         git push --force origin fastlane-android

--- a/.github/actions/screenshot-ios/action.yml
+++ b/.github/actions/screenshot-ios/action.yml
@@ -64,7 +64,7 @@ runs:
         # Force push to fastlane branch
         git checkout --orphan temporary
         git add --all .
-        git commit -am "[Auto] Update screenshots for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
+        git commit -am "[Auto] Update screenshots ($(date +%Y-%m-%d.%H:%M:%S))"
         git branch -D fastlane-ios
         git branch -m fastlane-ios
         git push --force origin fastlane-ios


### PR DESCRIPTION
Fixes a small issue in the commit messages for the screenshot workflows.

## Summary by Sourcery

CI:
- Standardize the commit messages for screenshot updates.