### PR TITLE
fix: update github events to be avoid negation

### DIFF
--- a/.github/actions/ios/action.yml
+++ b/.github/actions/ios/action.yml
@@ -35,7 +35,7 @@ runs:
         flutter build ipa --no-codesign --build-name $VERSION_NAME --build-number $VERSION_CODE
 
     - name: Build iOS IPA (With Code Signing)
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name == 'push' }}
       shell: bash
       env:
         VERSION_NAME: ${{ inputs.VERSION_NAME }}

--- a/.github/actions/screenshot-android/action.yml
+++ b/.github/actions/screenshot-android/action.yml
@@ -68,7 +68,7 @@ runs:
           DEVICE_NAME="Pixel 6" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d emulator
 
     - name: Update Fastlane Metadata
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name == 'push' }}
       shell: bash
       run: |
         git config --global user.name "github-actions[bot]"

--- a/.github/actions/screenshot-ios/action.yml
+++ b/.github/actions/screenshot-ios/action.yml
@@ -48,7 +48,7 @@ runs:
         DEVICE_NAME="${{ inputs.IPAD_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPAD_DEVICE_MODEL }}"
 
     - name: Update Fastlane Metadata
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name == 'push' }}
       shell: bash
       run: |
         git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update iOS, Android screenshot and iOS build workflows to only run on push events instead of on every event except for pull requests