### PR TITLE
chore: update automatic versioning

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,26 +33,34 @@ jobs:
           git clone --branch=version https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} version
           cd version
 
+          # Get commit message
+          commit_message=$(git log -1 --pretty=format:"%s")
+
           # Read and increment version name
           IFS='.' read -r major minor patch < versionName.txt
-          current_patch_version_name="$major.$minor.$patch"
-          echo "VERSION_NAME=$current_patch_version_name" >> $GITHUB_OUTPUT
-          
-          next_patch=$((patch + 1))
-          next_patch_version_name="$major.$minor.$next_patch"
-          echo "$next_patch_version_name" > versionName.txt
+
+          if [[ "$commit_message" =~ ^feat: ]]; then
+            next_minor=$((minor + 1))
+            next_patch=0
+          else
+            next_minor=$((minor))
+            next_patch=$((patch + 1))
+          fi
+          next_version_name="$major.$next_minor.$next_patch"
+          echo "VERSION_NAME=$next_version_name" >> $GITHUB_OUTPUT
+          echo "$next_version_name" > versionName.txt
 
           # Read and increment version code
           read -r version_code < versionCode.txt
-          echo "VERSION_CODE=$version_code" >> $GITHUB_OUTPUT
           
           new_version_code=$((version_code + 1))
+          echo "VERSION_CODE=$new_version_code" >> $GITHUB_OUTPUT
           echo "$new_version_code" > versionCode.txt
 
           # Force push to version branch
           git checkout --orphan temporary
           git add --all .
-          git commit -am "[Auto] Update versionName: $next_patch_version_name & versionCode: $new_version_code ($(date +%Y-%m-%d.%H:%M:%S))"
+          git commit -am "[Auto] Update versionName: $next_version_name & versionCode: $new_version_code ($(date +%Y-%m-%d.%H:%M:%S))"
           git branch -D version
           git branch -m version
           git push --force origin version


### PR DESCRIPTION
The idea is simple:

1. Every **feat** increments the _minor_ version.
2. Anything else (**chore**, **fix**, **doc**, etc.) increments the _patch_ version.
3. _major_ version can never be incremented automatically, it's upon us to increment manually whenever we want to make a major release.

## Summary by Sourcery

Chores:
- Update the automatic versioning to increment the minor version for features and the patch version for other changes. The major version is not incremented automatically and requires manual updates for major releases