### PR TITLE
chore: added more screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ There are a number of devices with Bluetooth on the market. As far as we can tel
   </tr>
   <tr>
     <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-saved_badges.png" width="1080"/></td>
-    <td colspan="3">
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-saved_badges_clicked.png" width="1080"/></td>
+    <td colspan="2">
       <img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-draw_badge.png" width="2146"/>
     </td>
   </tr>

--- a/test_integration/screenshots.dart
+++ b/test_integration/screenshots.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:badgemagic/virtualbadge/view/draw_badge.dart';
 import 'package:extended_text_field/extended_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -60,6 +61,19 @@ void main() async {
       await tester.pump(const Duration(seconds: 5));
       await binding.takeScreenshot('text_badge');
 
+      final saveButton = find.text('Save');
+      await tester.tap(saveButton);
+      await tester.pumpAndSettle();
+
+      final saveBadgeButton = find.byWidgetPredicate(
+        (widget) =>
+            widget is TextButton &&
+            widget.child is Text &&
+            (widget.child as Text).data == 'Save',
+      );
+      await tester.tap(saveBadgeButton);
+      await tester.pumpAndSettle();
+
       await tester.tap(inputField);
       await tester.pumpAndSettle();
       tester.testTextInput.enterText('');
@@ -95,6 +109,12 @@ void main() async {
       await tester.pumpAndSettle();
       await binding.takeScreenshot('emoji_badge');
 
+      await tester.tap(saveButton);
+      await tester.pumpAndSettle();
+
+      await tester.tap(saveBadgeButton);
+      await tester.pumpAndSettle();
+
       final invertEffectContainer = find.text('Invert');
       await tester.tap(invertEffectContainer);
       await tester.pump(const Duration(seconds: 5));
@@ -120,12 +140,40 @@ void main() async {
       await tester.pumpAndSettle();
       await binding.takeScreenshot('saved_badges');
 
+      final playButton = find
+          .byWidgetPredicate(
+            (widget) =>
+                widget is IconButton &&
+                widget.icon is Image &&
+                (widget.icon as Image).image is AssetImage &&
+                ((widget.icon as Image).image as AssetImage).assetName ==
+                    "assets/icons/t_play.png",
+          )
+          .at(1);
+      await tester.tap(playButton);
+      await tester.pumpAndSettle();
+      final badgeSwitch = find.byType(Switch).at(1);
+      await tester.tap(badgeSwitch);
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+      await binding.takeScreenshot('saved_badges_clicked');
+
       state = tester.firstState(find.byType(Scaffold));
       state.openDrawer();
       await tester.pumpAndSettle();
       final drawBadgeText = find.text('Draw Clipart');
       await tester.tap(drawBadgeText);
       await pumpUntilFound(tester, drawBadgeScreenTitle);
+
+      final badgeFinder = find.byWidgetPredicate(
+        (widget) => widget is BMBadge,
+      );
+      await tester.drag(badgeFinder, const Offset(50, 0));
+      await tester.pumpAndSettle();
+      await tester.drag(badgeFinder, const Offset(-50, 0));
+      await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));


### PR DESCRIPTION
Adds support for capturing more screenshots.

## Changes
- The _Saved Badges_ screen is populated with some data before clicking a screenshot.
- A screenshot with one of the saved badges active is also clicked.
- _Draw Badge_ screen is captured after some minimal drawing on it.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Capture additional screenshots for various screens within the app, including the _Saved Badges_ screen with and without an active badge, and the _Draw Badge_ screen after some drawing activity. Update the README with the new screenshots.

Tests:
- Added integration tests to simulate user interaction and capture screenshots of the _Saved Badges_ and _Draw Badge_ screens in various states.

Chores:
- Added screenshots for the _Saved Badges_ screen in different states, including one with an active badge.
- Added screenshots for the _Draw Badge_ screen after performing some drawing actions.
- Updated the README file with the new screenshots.