### PR TITLE
chore: fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           git clone --branch=fastlane-android --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
           cd fastlane
           
-          echo "${{ github.event.release.body }}" > metadata/android/en-US/changelogs/${{ steps.download-assets.outputs.VERSION_CODE }}.txt
+          printf "%s" "${{ github.event.release.body }}" > "metadata/android/en-US/changelogs/${{ steps.download-assets.outputs.VERSION_CODE }}.txt"
           
           # Force push to fastlane branch
           git checkout --orphan temporary
@@ -72,7 +72,7 @@ jobs:
           git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
           cd fastlane
           
-          echo "${{ github.event.release.body }}" > metadata/en-US/release_notes.txt
+          printf "%s" "${{ github.event.release.body }}" > "metadata/en-US/release_notes.txt"
           
           # Force push to fastlane branch
           git checkout --orphan temporary


### PR DESCRIPTION
Fixes our _release_ pipeline.

## Summary by Sourcery

Fixes the release pipeline by using `printf` instead of `echo` to write the release notes to the changelog files.

Bug Fixes:
- Fixes an issue in the release pipeline where the release notes were not being correctly written to the changelog files.

CI:
- Uses `printf` instead of `echo` to write the release notes to the changelog files in the release pipeline, avoiding potential formatting issues.