### PR TITLE
chore: arrange screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ There are a number of devices with Bluetooth on the market. As far as we can tel
 
 <table>
   <tr>
-    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-home_screen.png" width="1080"/></td>
-    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-text_badge.png" width="1080"/></td>
-    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-emoji_badge.png" width="1080"/></td>
-    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-inverted_emoji_badge.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-1_home_screen.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-2_text_badge.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-3_emoji_badge.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-4_inverted_emoji_badge.png" width="1080"/></td>
   </tr>
   <tr>
-    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-saved_badges.png" width="1080"/></td>
-    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-saved_badges_clicked.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-5_saved_badges.png" width="1080"/></td>
+    <td><img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-6_saved_badges_clicked.png" width="1080"/></td>
     <td colspan="2">
-      <img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-draw_badge.png" width="2146"/>
+      <img src="https://github.com/fossasia/badgemagic-app/blob/fastlane-android/metadata/android/en-US/images/phoneScreenshots/Pixel_6-7_draw_badge.png" width="2146"/>
     </td>
   </tr>
 </table>

--- a/test_integration/screenshots.dart
+++ b/test_integration/screenshots.dart
@@ -34,7 +34,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('home_screen');
+      await binding.takeScreenshot('1_home_screen');
 
       final animationTabText = find.text('Animation');
       await tester.tap(animationTabText);
@@ -59,7 +59,7 @@ void main() async {
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
-      await binding.takeScreenshot('text_badge');
+      await binding.takeScreenshot('2_text_badge');
 
       final saveButton = find.text('Save');
       await tester.tap(saveButton);
@@ -107,7 +107,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('emoji_badge');
+      await binding.takeScreenshot('3_emoji_badge');
 
       await tester.tap(saveButton);
       await tester.pumpAndSettle();
@@ -121,7 +121,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('inverted_emoji_badge');
+      await binding.takeScreenshot('4_inverted_emoji_badge');
 
       await tester.tap(invertEffectContainer);
       await tester.pumpAndSettle();
@@ -138,7 +138,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('saved_badges');
+      await binding.takeScreenshot('5_saved_badges');
 
       final playButton = find
           .byWidgetPredicate(
@@ -158,7 +158,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('saved_badges_clicked');
+      await binding.takeScreenshot('6_saved_badges_clicked');
 
       state = tester.firstState(find.byType(Scaffold));
       state.openDrawer();
@@ -178,7 +178,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 5));
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('draw_badge');
+      await binding.takeScreenshot('7_draw_badge');
     });
   });
 }


### PR DESCRIPTION
Prefixes screenshot names so that they are properly arranged on the PlayStore and the AppStore.

## Summary by Sourcery

Renames screenshot files and updates screenshot tests to ensure correct ordering of screenshots in app stores.

Tests:
- Updates screenshot tests to reflect the new screenshot naming scheme.

Chores:
- Prefixes screenshot names to ensure correct ordering in the PlayStore and AppStore listings.