### PR TITLE
fix: rating link on Apple Store goes to Android #1172

### DIFF
--- a/lib/view/widgets/navigation_drawer.dart
+++ b/lib/view/widgets/navigation_drawer.dart
@@ -1,6 +1,7 @@
 import 'package:badgemagic/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
+import 'dart:io';
 
 class BMDrawer extends StatefulWidget {
   final int selectedIndex;
@@ -118,8 +119,9 @@ class _BMDrawerState extends State<BMDrawer> {
             icon: Icons.star,
             title: 'Rate Us',
             routeName: '/rateUs',
-            externalLink:
-                'https://play.google.com/store/apps/details?id=org.fossasia.badgemagic',
+            externalLink: Platform.isIOS
+                ? 'https://apps.apple.com/us/app/badge-magic/id6740176888?action=write-review'
+                : 'https://play.google.com/store/apps/details?id=org.fossasia.badgemagic',
           ),
           _buildListTile(
             index: 9,


### PR DESCRIPTION
Fixes #1172

## Changes 
- <!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x ] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x ] **No end of file edits**: No modifications done at end of resource files.
- [x ] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x ] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Bug Fixes:
- Fixes the rating link in the navigation drawer to redirect iOS users to the Apple App Store.