### PR TITLE
fix: Layouts don't respect orientation on iPad 

### DIFF
--- a/iOS/Runner/Info.plist
+++ b/iOS/Runner/Info.plist
@@ -45,7 +45,6 @@
 		<key>UISupportedInterfaceOrientations~ipad</key>
 		<array>
 			<string>UIInterfaceOrientationPortrait</string>
-			<string>UIInterfaceOrientationPortraitUpsideDown</string>
 			<string>UIInterfaceOrientationLandscapeLeft</string>
 			<string>UIInterfaceOrientationLandscapeRight</string>
 		</array>
@@ -60,5 +59,7 @@
 		<true />
 		<key>ITSAppUsesNonExemptEncryption</key>
 		<false/>
+		<key>UIRequiresFullScreen</key>
+		<true/>
 	</dict>
 </plist>

--- a/iOS/Runner/Info.plist
+++ b/iOS/Runner/Info.plist
@@ -45,6 +45,7 @@
 		<key>UISupportedInterfaceOrientations~ipad</key>
 		<array>
 			<string>UIInterfaceOrientationPortrait</string>
+			<string>UIInterfaceOrientationPortraitUpsideDown</string>
 			<string>UIInterfaceOrientationLandscapeLeft</string>
 			<string>UIInterfaceOrientationLandscapeRight</string>
 		</array>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:badgemagic/view/save_badge_screen.dart';
 import 'package:badgemagic/view/saved_clipart.dart';
 import 'package:badgemagic/view/settings_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'globals/globals.dart' as globals;
@@ -14,6 +15,9 @@ import 'globals/globals.dart' as globals;
 void main() {
   setupLocator();
   WidgetsFlutterBinding.ensureInitialized();
+  SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+  ]);
   runApp(MultiProvider(
     providers: [
       ChangeNotifierProvider<InlineImageProvider>(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
   SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
   ]);
   runApp(MultiProvider(
     providers: [

--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -28,6 +28,14 @@ class _DrawBadgeState extends State<DrawBadge> {
   var drawToggle = DrawBadgeProvider();
 
   @override
+  void initState() {
+    super.initState();
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeRight,
+    ]);
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _setLandscapeOrientation();
@@ -48,7 +56,6 @@ class _DrawBadgeState extends State<DrawBadge> {
 
   void _setLandscapeOrientation() {
     SystemChrome.setPreferredOrientations([
-      DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
     ]);
   }

--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -28,14 +28,6 @@ class _DrawBadgeState extends State<DrawBadge> {
   var drawToggle = DrawBadgeProvider();
 
   @override
-  void initState() {
-    super.initState();
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.landscapeRight,
-    ]);
-  }
-
-  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _setLandscapeOrientation();
@@ -57,6 +49,7 @@ class _DrawBadgeState extends State<DrawBadge> {
   void _setLandscapeOrientation() {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.landscapeRight,
+      DeviceOrientation.landscapeLeft,
     ]);
   }
 


### PR DESCRIPTION
Fixes 
-This PR fixes issue #1190 by fixing the required orientation for particular screens on iPad.

## Changes 
- Updated Info.plist for iPad to restrict orientation to portrait.
- used `SystemChrome.setPreferredOrientations` for particular screens.

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [ ] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [ ] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.


Fixes #1190.

## Summary by Sourcery
