### PR TITLE
chore: add flutter submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "submodules/flutter"]
+	path = submodules/flutter
+	url = https://github.com/flutter/flutter.git
+	branch = stable

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,5 +24,9 @@ linter:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
+analyzer:
+  exclude:
+    - "submodules"
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -850,5 +850,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.24.0"


### PR DESCRIPTION
Adds the _flutter_ submodule to our repository to enable building with _FDroid_.

## Summary by Sourcery

Adds the flutter submodule to the repository and excludes it from analysis.

Chores:
- Adds flutter submodule.
- Excludes the flutter submodule from analysis.