### PR TITLE
fix: build.gradle for fdroid build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -69,8 +69,9 @@ android {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            if (LOCAL_KEY_PRESENT || GITHUB_BUILD)
+            if (LOCAL_KEY_PRESENT || GITHUB_BUILD) {
                 signingConfig signingConfigs.release
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes our _build.gradle_ file.

## Summary by Sourcery

Fixes the build.gradle file by adding a missing curly brace to the release signing config.