### PR TITLE
feat: Prevent Transfer Button from Overlapping Last List Item on Saved Badges Screen.

### DIFF
--- a/lib/view/save_badge_screen.dart
+++ b/lib/view/save_badge_screen.dart
@@ -128,14 +128,21 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                     children: [
                       AnimationBadge(),
                       Expanded(
-                        child: BadgeListView(
-                          futureBadges: Future.value(provider.savedBadgeCache),
-                          refreshBadgesCallback: (value) {
-                            provider.savedBadgeCache.remove(value);
-                            setState(() {});
-                            return Future.value();
-                          },
-                        ),
+                        child: Selector<BadgeSlotProvider, bool>(
+                            selector: (context, selectionProvider) =>
+                                selectionProvider.selectedBadges.isNotEmpty,
+                            builder: (context, isTransferEnabled, _) {
+                              return BadgeListView(
+                                isTransferEnabled: isTransferEnabled,
+                                futureBadges:
+                                    Future.value(provider.savedBadgeCache),
+                                refreshBadgesCallback: (value) {
+                                  provider.savedBadgeCache.remove(value);
+                                  setState(() {});
+                                  return Future.value();
+                                },
+                              );
+                            }),
                       ),
                     ],
                   ),

--- a/lib/view/widgets/saved_badge_listview.dart
+++ b/lib/view/widgets/saved_badge_listview.dart
@@ -3,11 +3,13 @@ import 'package:flutter/material.dart';
 
 class BadgeListView extends StatelessWidget {
   final Future<List<MapEntry<String, Map<String, dynamic>>>> futureBadges;
+  final bool isTransferEnabled;
   final Future<void> Function(MapEntry<String, Map<String, dynamic>>)
       refreshBadgesCallback; // Add callback for refreshing badges
 
   const BadgeListView(
       {super.key,
+      required this.isTransferEnabled,
       required this.futureBadges,
       required this.refreshBadgesCallback // Require the callback
       });
@@ -22,15 +24,18 @@ class BadgeListView extends StatelessWidget {
         } else {
           List<MapEntry<String, Map<String, dynamic>>> savedBadges =
               snapshot.data!;
-          return ListView.builder(
-            itemCount: savedBadges.length,
-            itemBuilder: (context, index) {
-              return SaveBadgeCard(
-                badgeData: savedBadges[index],
-                refreshBadgesCallback:
-                    refreshBadgesCallback, // Pass callback to card
-              );
-            },
+          return Padding(
+            padding: EdgeInsets.only(bottom: isTransferEnabled ? 75.0 : 0),
+            child: ListView.builder(
+              itemCount: savedBadges.length,
+              itemBuilder: (context, index) {
+                return SaveBadgeCard(
+                  badgeData: savedBadges[index],
+                  refreshBadgesCallback:
+                      refreshBadgesCallback, // Pass callback to card
+                );
+              },
+            ),
           );
         }
       },


### PR DESCRIPTION
Fixes #<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->**1253**

## Changes 
- Resolved the issue where the Transfer button overlapped the last list item, making its toggle button inaccessible.
- Added bottom padding (70.0) to ListView when selectionProvider.selectedBadges.isNotEmpty is true to prevent overlap.
- Replaced Consumer with Selector to optimize re-renders, ensuring the list only rebuilds when selectedBadges.isNotEmpty changes instead of on every toggle.
- Improved performance by reducing unnecessary widget rebuilds.


## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

https://github.com/user-attachments/assets/fff71027-c09f-48c8-aebf-887cd5aa6121



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Addresses an issue where the transfer button overlapped the last item in the list of saved badges, making the toggle button inaccessible. Implements a performance optimization by using Selector to prevent unnecessary widget rebuilds.

Bug Fixes:
- Fixes an issue where the Transfer button overlapped the last list item, making its toggle button inaccessible.

Enhancements:
- Improves performance by reducing unnecessary widget rebuilds by using Selector instead of Consumer to limit rebuilds to when selectedBadges.isNotEmpty changes.