### PR TITLE
feat: Add validation to prevent saving empty message in Saved Badges.

### DIFF
--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:badgemagic/bademagic_module/utils/byte_array_utils.dart';
 import 'package:badgemagic/bademagic_module/utils/converters.dart';
 import 'package:badgemagic/bademagic_module/utils/image_utils.dart';
+import 'package:badgemagic/bademagic_module/utils/toast_utils.dart';
 import 'package:badgemagic/badge_effect/flash_effect.dart';
 import 'package:badgemagic/badge_effect/invert_led_effect.dart';
 import 'package:badgemagic/badge_effect/marquee_effect.dart';
@@ -254,6 +255,13 @@ class _HomeScreenState extends State<HomeScreen>
                             children: [
                               GestureDetector(
                                 onTap: () {
+                                  if (inlineimagecontroller.text
+                                      .trim()
+                                      .isEmpty) {
+                                    ToastUtils().showErrorToast(
+                                        "Please enter a message");
+                                    return;
+                                  }
                                   logger.i(
                                       'Save button clicked, showing dialog : ${animationProvider.isEffectActive(FlashEffect())}');
                                   showDialog(


### PR DESCRIPTION
Fixes #<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->**1255**

This PR fixes a loophole where users could save an empty message to Saved Badges and later transfer it, bypassing validation.

## Changes 
- Added a validation check before opening the Save Badge dialog.
- Now, if the message field is empty, an error toast appears, and the badge is not saved.
- Prevents empty messages from being transferred through Saved Badges.

## Steps to Test:
- Navigate to HomeScreen.
- Leave the message TextField empty.
- Click Transfer → Error should appear as expected.
- Click Save → No empty message should be saved.
- Verify that Saved Badges does not contain an empty message.

## Impact:
- Ensures all saved and transferred messages are valid.
- Prevents users from bypassing validation through Saved Badges.
- Improves overall data integrity and user experience.

## Screenshots / Recordings  

https://github.com/user-attachments/assets/72a0c6eb-c134-4527-a50e-5f69c8138f7f




**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Bug Fixes:
- Prevents users from saving and transferring empty messages through Saved Badges, ensuring data integrity and a better user experience.