### PR TITLE
fix: display correct speed for the saved badges

### DIFF
--- a/lib/view/widgets/save_badge_card.dart
+++ b/lib/view/widgets/save_badge_card.dart
@@ -1,3 +1,4 @@
+import 'package:badgemagic/bademagic_module/models/speed.dart';
 import 'package:badgemagic/bademagic_module/utils/byte_array_utils.dart';
 import 'package:badgemagic/bademagic_module/utils/converters.dart';
 import 'package:badgemagic/bademagic_module/utils/file_helper.dart';
@@ -250,12 +251,11 @@ class SaveBadgeCard extends StatelessWidget {
                       ),
                       const SizedBox(width: 4),
                       Text(
-                        file
-                            .jsonToData(badgeData.value)
-                            .messages[0]
-                            .speed
-                            .hexValue
-                            .substring(2, 3),
+                        (Speed.getIntValue(file
+                                    .jsonToData(badgeData.value)
+                                    .messages[0]
+                                    .speed)+1)
+                            .toString(),
                         style: const TextStyle(color: Colors.white),
                       ),
                     ],

--- a/lib/view/widgets/save_badge_card.dart
+++ b/lib/view/widgets/save_badge_card.dart
@@ -254,7 +254,8 @@ class SaveBadgeCard extends StatelessWidget {
                         (Speed.getIntValue(file
                                     .jsonToData(badgeData.value)
                                     .messages[0]
-                                    .speed)+1)
+                                    .speed) +
+                                1)
                             .toString(),
                         style: const TextStyle(color: Colors.white),
                       ),


### PR DESCRIPTION
Fixes #1269 
## Changes 
- Utlized  getIntValue Function defined in speed.dart to get the integer value , and added 1 to it to display the exact speed value.

## Screenshots / Recordings  
https://github.com/user-attachments/assets/503b144b-7cb8-4dbe-a7db-bd4686d900b3



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Bug Fixes:
- Corrected the speed value display by using the getIntValue function and adding 1 to show the exact speed value