### PR TITLE
fix: added the removeIfGone parameter to remove the cahced device onc…

### DIFF
--- a/lib/bademagic_module/bluetooth/scan_state.dart
+++ b/lib/bademagic_module/bluetooth/scan_state.dart
@@ -51,6 +51,8 @@ class ScanState extends NormalBleState {
 
       await FlutterBluePlus.startScan(
         withServices: [Guid("0000fee0-0000-1000-8000-00805f9b34fb")],
+        removeIfGone: Duration(seconds: 5),
+        continuousUpdates: true,
         timeout: const Duration(seconds: 15), // Reduced scan timeout
       );
 


### PR DESCRIPTION
…e stops advertising.

Fixes #1291 

## Changes 
- added the parameter removeIFGone with continuous updates to remove the already connected badge.

## Screenshots / Recordings  
NA

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [ ] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [ ] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Improve Bluetooth scanning by automatically removing devices that stop advertising and providing continuous updates to the device list.

New Features:
- Added removeIfGone parameter to Bluetooth scan to remove devices that stop advertising.

Enhancements:
- Enabled continuousUpdates for Bluetooth scanning to improve device list accuracy.