### PR TITLE
chore: use latest SDK to build IPAs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,6 +45,11 @@ jobs:
     needs: common
     runs-on: macos-latest
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest
+
       - uses: actions/checkout@v4
 
       - name: iOS Workflow
@@ -66,6 +71,11 @@ jobs:
     name: Screenshots (iOS)
     runs-on: macos-latest
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest
+
       - uses: actions/checkout@v4
 
       - name: iOS Screenshot Workflow

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -158,6 +158,11 @@ jobs:
     needs: common
     runs-on: macos-latest
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest
+
       - uses: actions/checkout@v4
 
       - name: Prepare Build Keys


### PR DESCRIPTION
Fixes #1293 
Sets up the _macos-latest_ runner with the latest version of Xcode, to use the latest iOS SDK to build IPAs.


## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Add a "Set up Xcode" step to CI workflows to ensure the macos-latest runner uses the latest Xcode and iOS SDK when building IPAs

CI:
- Add maxim-lobanov/setup-xcode@v1.6.0 step in pull_request.yml to select the latest Xcode version
- Add maxim-lobanov/setup-xcode@v1.6.0 step in push.yml to select the latest Xcode version
- Apply the new Xcode setup step to both build and screenshot workflow jobs