### PR TITLE
chore: added cron job to clean PR screenshots periodically

### DIFF
--- a/.github/workflows/clean_screenshots.yml
+++ b/.github/workflows/clean_screenshots.yml
@@ -1,0 +1,42 @@
+name: Clean PR Screenshots
+
+on:
+  schedule:
+  - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: pr-screenshots
+            
+      - name: Delete screenshots from closed PRs
+        run: |
+          open_prs=$(gh pr list --state open --json number -q '.[].number')
+
+          for file in *.png; do
+            pr_num=$(echo "$file" | cut -d'_' -f1)
+            if ! echo "$open_prs" | grep -qw "$pr_num"; then
+                rm "$file"
+                fi
+            done
+            
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Force push to pr-screenshots branch
+          git checkout --orphan temporary
+          git add --all .
+          git commit -am "[Auto] Clean screenshots ($(date +%Y-%m-%d.%H:%M:%S))"
+          git branch -D pr-screenshots
+          git branch -m pr-screenshots
+          git push --force origin pr-screenshots


### PR DESCRIPTION
Adds a _cron_ job to periodically remove residual screenshots in the `pr-screenshots` branch.

This has already been tested by me.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

CI:
- Schedule a weekly cron job to remove screenshots for closed PRs and force-push the cleaned branch.