### PR TITLE
fix: Display randomly disappears due to missing state update

### DIFF
--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -64,7 +64,6 @@ class _HomeScreenState extends State<HomeScreen>
     _startImageCaching();
     speedDialProvider = SpeedDialProvider(animationProvider);
     super.initState();
-
     _tabController = TabController(length: 3, vsync: this);
   }
 
@@ -355,7 +354,10 @@ class _HomeScreenState extends State<HomeScreen>
       previousText = '';
       animationProvider.stopAllAnimations();
       animationProvider.initializeAnimation();
-      setState(() {});
+      if (mounted) setState(() {});
+    } else if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.inactive) {
+      animationProvider.stopAnimation();
     }
   }
 }

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -34,7 +34,10 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen>
-    with TickerProviderStateMixin, AutomaticKeepAliveClientMixin {
+    with
+        TickerProviderStateMixin,
+        AutomaticKeepAliveClientMixin,
+        WidgetsBindingObserver {
   late final TabController _tabController;
   AnimationBadgeProvider animationProvider = AnimationBadgeProvider();
   late SpeedDialProvider speedDialProvider;
@@ -52,6 +55,7 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   void initState() {
+    WidgetsBinding.instance.addObserver(this);
     inlineimagecontroller.addListener(handleTextChange);
     _setPortraitOrientation();
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -102,6 +106,7 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     inlineimagecontroller.removeListener(handleTextChange);
     animationProvider.stopAnimation();
     inlineImageProvider.getController().removeListener(_controllerListner);
@@ -341,4 +346,16 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   bool get wantKeepAlive => true;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      inlineimagecontroller.clear();
+      previousText = '';
+      animationProvider.stopAllAnimations();
+      animationProvider.initializeAnimation();
+      setState(() {});
+    }
+  }
 }


### PR DESCRIPTION
Fixes #1307

## Changes 

- Added `WidgetsBindingObserver` to `_HomeScreenState` to monitor app lifecycle.
- Registered the observer in `initState` and removed it in dispose.
- Implemented `didChangeAppLifecycleState` to reset inlineimagecontroller, clear previous text, reinitialize animation, and call `setState()` when the app resumes.
- This ensures proper UI refresh and animation reinitialization when returning to the HomeScreen.

**Checklist**: 
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Monitor app lifecycle in HomeScreen and reset UI state and animations on app resume to prevent display issues.

Bug Fixes:
- Prevent HomeScreen UI from disappearing randomly by clearing controllers, resetting text, and rebuilding when the app resumes

Enhancements:
- Add WidgetsBindingObserver to HomeScreenState to track lifecycle changes and reinitialize animations and controllers on resume