### PR TITLE
fix: BLE Connection Allows Only One Update Requires App Restart for Reconnect or Text Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 .gradle/
 

--- a/lib/bademagic_module/bluetooth/base_ble_state.dart
+++ b/lib/bademagic_module/bluetooth/base_ble_state.dart
@@ -18,6 +18,7 @@ abstract class NormalBleState extends BleState {
       return await processState();
     } on Exception catch (e) {
       String errorMessage = e.toString().replaceFirst('Exception: ', '');
+      logger.e("BLE state failed: $errorMessage");
       return CompletedState(isSuccess: false, message: errorMessage);
     }
   }
@@ -27,7 +28,7 @@ abstract class RetryBleState extends BleState {
   final logger = Logger();
   final toast = ToastUtils();
 
-  final _maxRetries = 3;
+  final int _maxRetries = 3;
 
   Future<BleState?> processState();
 
@@ -40,22 +41,23 @@ abstract class RetryBleState extends BleState {
       try {
         return await processState();
       } on Exception catch (e) {
-        logger.e(e);
+        logger.e("BLE retry attempt ${attempt + 1} failed: $e");
         lastException = e;
         attempt++;
+
         if (attempt < _maxRetries) {
-          logger.d("Retrying ($attempt/$_maxRetries)...");
+          logger.d("Retrying BLE state ($attempt/$_maxRetries)...");
+          await Future.delayed(Duration(seconds: 1));
         } else {
           logger.e("Max retries reached. Last exception: $lastException");
-          lastException =
-              Exception("Max retries reached. Last exception: $lastException");
         }
       }
     }
 
-    // After max retries, return a CompletedState indicating failure.
     return CompletedState(
-        isSuccess: false,
-        message: lastException?.toString() ?? "Unknown error");
+      isSuccess: false,
+      message: lastException?.toString().replaceFirst('Exception: ', '') ??
+          "Unknown error",
+    );
   }
 }

--- a/lib/bademagic_module/bluetooth/connect_state.dart
+++ b/lib/bademagic_module/bluetooth/connect_state.dart
@@ -24,7 +24,18 @@ class ConnectState extends RetryBleState {
         logger.d("Device connected");
         toast.showToast('Device connected successfully.');
 
-        return WriteState(device: scanResult.device, manager: manager);
+        final writeState =
+            WriteState(device: scanResult.device, manager: manager);
+        final result = await writeState.process();
+        try {
+          await scanResult.device.disconnect();
+          logger.d("Device disconnected after transfer");
+          await Future.delayed(const Duration(seconds: 1));
+          logger.d("Waited 1s after disconnect");
+        } catch (e) {
+          logger.e("Error during disconnect after transfer: $e");
+        }
+        return result;
       } else {
         throw Exception("Failed to connect to the device");
       }
@@ -33,7 +44,14 @@ class ConnectState extends RetryBleState {
       rethrow;
     } finally {
       if (!connected) {
-        await scanResult.device.disconnect();
+        try {
+          await scanResult.device.disconnect();
+          logger.d("Device disconnected in finally block");
+          await Future.delayed(const Duration(seconds: 1));
+          logger.d("Waited 1s after disconnect (finally)");
+        } catch (e) {
+          logger.e("Error during disconnect in finally: $e");
+        }
       }
     }
   }

--- a/lib/bademagic_module/bluetooth/connect_state.dart
+++ b/lib/bademagic_module/bluetooth/connect_state.dart
@@ -11,48 +11,37 @@ class ConnectState extends RetryBleState {
 
   @override
   Future<BleState?> processState() async {
-    bool connected = false;
-
     try {
-      await scanResult.device.connect(autoConnect: false);
+      // Check if already connected before trying to connect
+      BluetoothConnectionState currentState =
+          await scanResult.device.connectionState.first;
+
+      if (currentState != BluetoothConnectionState.connected) {
+        await scanResult.device.connect(autoConnect: false);
+        logger.d("Device connection initiated");
+      }
+
+      // Re-check connection status after connect
       BluetoothConnectionState connectionState =
           await scanResult.device.connectionState.first;
 
       if (connectionState == BluetoothConnectionState.connected) {
-        connected = true;
-
         logger.d("Device connected");
         toast.showToast('Device connected successfully.');
 
         final writeState =
             WriteState(device: scanResult.device, manager: manager);
         final result = await writeState.process();
-        try {
-          await scanResult.device.disconnect();
-          logger.d("Device disconnected after transfer");
-          await Future.delayed(const Duration(seconds: 1));
-          logger.d("Waited 1s after disconnect");
-        } catch (e) {
-          logger.e("Error during disconnect after transfer: $e");
-        }
+
+        // Do NOT disconnect again here; WriteState handles it
         return result;
       } else {
-        throw Exception("Failed to connect to the device");
+        throw Exception("Failed to connect to the device.");
       }
     } catch (e) {
-      toast.showErrorToast('Failed to connect retrying...');
+      toast.showErrorToast('Failed to connect, retrying...');
+      logger.e("BLE connection error: $e");
       rethrow;
-    } finally {
-      if (!connected) {
-        try {
-          await scanResult.device.disconnect();
-          logger.d("Device disconnected in finally block");
-          await Future.delayed(const Duration(seconds: 1));
-          logger.d("Waited 1s after disconnect (finally)");
-        } catch (e) {
-          logger.e("Error during disconnect in finally: $e");
-        }
-      }
     }
   }
 }

--- a/lib/bademagic_module/bluetooth/scan_state.dart
+++ b/lib/bademagic_module/bluetooth/scan_state.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 import 'package:badgemagic/bademagic_module/bluetooth/connect_state.dart';
 import 'package:badgemagic/bademagic_module/bluetooth/datagenerator.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
-
 import 'base_ble_state.dart';
 
 class ScanState extends NormalBleState {
   final DataTransferManager manager;
+
   ScanState({required this.manager});
 
   @override
@@ -17,49 +17,55 @@ class ScanState extends NormalBleState {
     Completer<BleState?> nextStateCompleter = Completer();
     bool isCompleted = false;
 
-    ScanResult? foundDevice;
-
     try {
       subscription = FlutterBluePlus.scanResults.listen(
         (results) async {
-          if (!isCompleted) {
-            if (results.isNotEmpty) {
-              foundDevice = results.firstWhere(
+          if (!isCompleted && results.isNotEmpty) {
+            try {
+              final foundDevice = results.firstWhere(
                 (result) => result.advertisementData.serviceUuids
                     .contains(Guid("0000fee0-0000-1000-8000-00805f9b34fb")),
+                orElse: () => throw Exception("Matching device not found."),
               );
-              if (foundDevice != null) {
-                toast.showToast('Device found. Connecting...');
-                isCompleted = true;
-                nextStateCompleter.complete(ConnectState(
-                  scanResult: foundDevice!,
-                  manager: manager,
-                ));
-              }
+
+              toast.showToast('Device found. Connecting...');
+              isCompleted = true;
+              FlutterBluePlus.stopScan();
+
+              nextStateCompleter.complete(ConnectState(
+                scanResult: foundDevice,
+                manager: manager,
+              ));
+            } catch (e) {
+              // Ignore and keep scanning
             }
           }
         },
-        onError: (e) async {
+        onError: (e) {
           if (!isCompleted) {
             isCompleted = true;
+            FlutterBluePlus.stopScan();
             logger.e("Scan error: $e");
             toast.showErrorToast('Scan error occurred.');
-            nextStateCompleter.completeError(e);
+            nextStateCompleter
+                .completeError(Exception("Error during scanning: $e"));
           }
         },
       );
 
       await FlutterBluePlus.startScan(
         withServices: [Guid("0000fee0-0000-1000-8000-00805f9b34fb")],
-        removeIfGone: Duration(seconds: 5),
+        removeIfGone: const Duration(seconds: 5),
         continuousUpdates: true,
-        timeout: const Duration(seconds: 15), // Reduced scan timeout
+        timeout: const Duration(seconds: 15),
       );
 
+      // Small buffer delay for late events
       await Future.delayed(const Duration(seconds: 1));
 
-      // If no device is found after the scan timeout, complete with an error.
       if (!isCompleted) {
+        isCompleted = true;
+        FlutterBluePlus.stopScan();
         toast.showToast('Device not found.');
         nextStateCompleter.completeError(Exception('Device not found.'));
       }
@@ -67,7 +73,7 @@ class ScanState extends NormalBleState {
       return await nextStateCompleter.future;
     } catch (e) {
       logger.e("Exception during scanning: $e");
-      throw Exception("please check the device is turned on and retry.");
+      throw Exception("Please check if the device is turned on and retry.");
     } finally {
       await subscription?.cancel();
     }

--- a/lib/bademagic_module/bluetooth/write_state.dart
+++ b/lib/bademagic_module/bluetooth/write_state.dart
@@ -13,8 +13,10 @@ class WriteState extends NormalBleState {
   Future<BleState?> processState() async {
     List<List<int>> dataChunks = await manager.generateDataChunk();
     logger.d("Data to write: $dataChunks");
+
     try {
       List<BluetoothService> services = await device.discoverServices();
+
       for (BluetoothService service in services) {
         for (BluetoothCharacteristic characteristic
             in service.characteristics) {
@@ -23,35 +25,45 @@ class WriteState extends NormalBleState {
               characteristic.properties.write) {
             for (List<int> chunk in dataChunks) {
               bool success = false;
+
               for (int attempt = 1; attempt <= 3; attempt++) {
                 try {
                   await characteristic.write(chunk, withoutResponse: false);
+                  logger.d("Chunk written successfully: $chunk");
                   success = true;
                   break;
                 } catch (e) {
-                  logger.e("Write failed, retrying ([36m$attempt/3[0m): $e");
+                  logger.e("Write failed (attempt $attempt/3): $e");
                 }
               }
+
               if (!success) {
-                throw Exception("Failed to transfer data. Please try again.");
+                throw Exception(
+                    "Failed to write data chunk. Please try again.");
               }
+
+              await Future.delayed(
+                  Duration(milliseconds: 50)); // Prevent badge overload
             }
-            logger.d("Characteristic written successfully");
+
+            logger.d("All data written successfully.");
             return CompletedState(
-                isSuccess: true, message: "Data transferred successfully");
+              isSuccess: true,
+              message: "Data transferred successfully",
+            );
           }
         }
       }
-      throw Exception("Please use the correct Badge");
+
+      throw Exception("Writable characteristic not found. Use a valid badge.");
     } catch (e) {
-      logger.e("Failed to write characteristic: $e");
+      logger.e("Error while writing data: $e");
       throw Exception("Failed to transfer data. Please try again.");
     } finally {
       try {
         await device.disconnect();
-        logger.d("Device disconnected after write");
-        await Future.delayed(const Duration(seconds: 1));
-        logger.d("Waited 1s after disconnect");
+        await Future.delayed(Duration(seconds: 1)); // Ensure BLE reset
+        logger.d("Disconnected from device after write.");
       } catch (e) {
         logger.e("Error during disconnect: $e");
       }

--- a/lib/bademagic_module/bluetooth/write_state.dart
+++ b/lib/bademagic_module/bluetooth/write_state.dart
@@ -13,7 +13,6 @@ class WriteState extends NormalBleState {
   Future<BleState?> processState() async {
     List<List<int>> dataChunks = await manager.generateDataChunk();
     logger.d("Data to write: $dataChunks");
-
     try {
       List<BluetoothService> services = await device.discoverServices();
       for (BluetoothService service in services) {
@@ -30,7 +29,7 @@ class WriteState extends NormalBleState {
                   success = true;
                   break;
                 } catch (e) {
-                  logger.e("Write failed, retrying ($attempt/3): $e");
+                  logger.e("Write failed, retrying ([36m$attempt/3[0m): $e");
                 }
               }
               if (!success) {
@@ -47,6 +46,15 @@ class WriteState extends NormalBleState {
     } catch (e) {
       logger.e("Failed to write characteristic: $e");
       throw Exception("Failed to transfer data. Please try again.");
+    } finally {
+      try {
+        await device.disconnect();
+        logger.d("Device disconnected after write");
+        await Future.delayed(const Duration(seconds: 1));
+        logger.d("Waited 1s after disconnect");
+      } catch (e) {
+        logger.e("Error during disconnect: $e");
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #1314

## Changes 

- Refactored BLE state management: ScanState, ConnectState, WriteState.
- Updated base_ble_state.dart to support state transitions more cleanly.
- Improved BLE handling to support Always-On mode with dynamic badge updates.
- Minor updates to .gitignore and macOS build-related files (Podfile.lock, Runner.xcodeproj, etc.).

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Refactor core BLE workflow for scanning, connecting, and writing to improve reliability and enable repeated dynamic badge updates in Always-On mode.

New Features:
- Support dynamic badge updates in Always-On mode.

Bug Fixes:
- Allow BLE reconnections and multiple data writes without restarting the app.
- Handle scan timeouts and errors by stopping scans and propagating accurate error messages.
- Ensure devices disconnect properly after data writes to reset BLE state.

Enhancements:
- Refactor BLE state management into separate ScanState, ConnectState, and WriteState classes with unified retry and logging logic.
- Implement chunked data writes with retry attempts, delays between chunks, and detailed logging.

Build:
- Update .gitignore and macOS build artifacts (Podfile.lock, Runner.xcodeproj) to exclude generated files.