### PR TITLE
chore: restore workflows to support renamed development branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: Badge Magic PR CI
 
 on:
   pull_request:
-    branches: [ "flutter_app" ]
+    branches: [ "development" ]
 
 env:
   ANDROID_EMULATOR_API: 34

--- a/.github/workflows/pull_request_closed.yml
+++ b/.github/workflows/pull_request_closed.yml
@@ -2,7 +2,7 @@ name: Delete Screenshots
 
 on:
   pull_request_target:
-    branches: [ "flutter_app" ]
+    branches: [ "development" ]
     types:
       - closed
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: Badge Magic Push CI
 
 on:
   push:
-    branches: ["flutter_app"]
+    branches: ["development"]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #1335

## Changes 

- Ensured all workflows now correctly reference the development branch.

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Restore CI workflows to trigger on the renamed development branch and extend HomeScreenState with app lifecycle observation to manage inline images and animations on resume/pause.

Enhancements:
- Add WidgetsBindingObserver to HomeScreenState to handle AppLifecycleState events, clearing inline images and managing animations on resume and pause.

CI:
- Update GitHub Actions workflows (pull_request, push, pull_request_closed) to reference the development branch instead of flutter_app.