### PR TITLE
chore: rename apk branch to app

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -112,14 +112,14 @@ jobs:
           name: AAB Generated
           path: build/app/outputs/bundle
       
-      - name: Upload APK/AAB to apk branch
+      - name: Upload APK/AAB to app branch
         if: ${{ github.repository == 'fossasia/badgemagic-app' }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git clone --branch=apk https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} apk
-          cd apk
+          git clone --branch=app https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} app
+          cd app
           
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
 
@@ -144,14 +144,14 @@ jobs:
 
           ls
 
-          echo "Pushing to apk branch"
+          echo "Pushing to app branch"
 
           git checkout --orphan temporary
           git add --all .
           git commit -am "[Auto] Update APK/AAB's from $branch ($(date +%Y-%m-%d.%H:%M:%S))"
-          git branch -D apk
-          git branch -m apk
-          git push --force origin apk
+          git branch -D app
+          git branch -m app
+          git push --force origin app
 
       - name: Push app in open testing track
         if: ${{ github.repository == 'fossasia/badgemagic-app' }}


### PR DESCRIPTION
Renames _apk_ branch to _app_ in our workflows.

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Update GitHub Actions workflow to rename the deployment branch from 'apk' to 'app'

CI:
- Rename branch references and clone commands in push.yml to use 'app' instead of 'apk'
- Update log messages and git branch operations in the CI workflow to target the 'app' branch