### PR TITLE
fix: Homescreen State management issue in iOS

### DIFF
--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -64,7 +64,6 @@ class _HomeScreenState extends State<HomeScreen>
     _startImageCaching();
     speedDialProvider = SpeedDialProvider(animationProvider);
     super.initState();
-
     _tabController = TabController(length: 3, vsync: this);
   }
 
@@ -355,7 +354,10 @@ class _HomeScreenState extends State<HomeScreen>
       previousText = '';
       animationProvider.stopAllAnimations();
       animationProvider.initializeAnimation();
-      setState(() {});
+      if (mounted) setState(() {});
+    } else if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.inactive) {
+      animationProvider.stopAnimation();
     }
   }
 }

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -66,6 +66,24 @@ class _HomeScreenState extends State<HomeScreen>
   }
 
   @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      _cachedText = inlineimagecontroller.text;
+      animationProvider.stopAnimation();
+    } else if (state == AppLifecycleState.resumed) {
+      if (inlineimagecontroller.text.trim().isEmpty &&
+          _cachedText.trim().isNotEmpty) {
+        inlineimagecontroller.text = _cachedText;
+      }
+      animationProvider.badgeAnimation(
+        inlineimagecontroller.text,
+        Converters(),
+        animationProvider.isEffectActive(InvertLEDEffect()),
+      );
+    }
+  }
+
+  @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     inlineimagecontroller.removeListener(handleTextChange);
@@ -319,21 +337,4 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   bool get wantKeepAlive => true;
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.paused) {
-      _cachedText = inlineimagecontroller.text;
-      animationProvider.stopAnimation();
-    } else if (state == AppLifecycleState.resumed) {
-      if (inlineimagecontroller.text.trim().isEmpty &&
-          _cachedText.trim().isNotEmpty) {
-        inlineimagecontroller.text = _cachedText;
-      }
-      animationProvider.badgeAnimation(
-        inlineimagecontroller.text,
-        Converters(),
-        animationProvider.isEffectActive(InvertLEDEffect()),
-      );
-    }
-  }
 }

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -34,7 +34,10 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen>
-    with TickerProviderStateMixin, AutomaticKeepAliveClientMixin {
+    with
+        TickerProviderStateMixin,
+        AutomaticKeepAliveClientMixin,
+        WidgetsBindingObserver {
   late final TabController _tabController;
   AnimationBadgeProvider animationProvider = AnimationBadgeProvider();
   late SpeedDialProvider speedDialProvider;
@@ -52,6 +55,7 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   void initState() {
+    WidgetsBinding.instance.addObserver(this);
     inlineimagecontroller.addListener(handleTextChange);
     _setPortraitOrientation();
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -102,6 +106,7 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     inlineimagecontroller.removeListener(handleTextChange);
     animationProvider.stopAnimation();
     inlineImageProvider.getController().removeListener(_controllerListner);
@@ -341,4 +346,16 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   bool get wantKeepAlive => true;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      inlineimagecontroller.clear();
+      previousText = '';
+      animationProvider.stopAllAnimations();
+      animationProvider.initializeAnimation();
+      setState(() {});
+    }
+  }
 }

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -1,6 +1,4 @@
 import 'dart:async';
-
-import 'package:badgemagic/bademagic_module/utils/byte_array_utils.dart';
 import 'package:badgemagic/bademagic_module/utils/converters.dart';
 import 'package:badgemagic/bademagic_module/utils/image_utils.dart';
 import 'package:badgemagic/bademagic_module/utils/toast_utils.dart';
@@ -39,19 +37,19 @@ class _HomeScreenState extends State<HomeScreen>
         AutomaticKeepAliveClientMixin,
         WidgetsBindingObserver {
   late final TabController _tabController;
-  AnimationBadgeProvider animationProvider = AnimationBadgeProvider();
   late SpeedDialProvider speedDialProvider;
-  BadgeMessageProvider badgeData = BadgeMessageProvider();
-  ImageUtils imageUtils = ImageUtils();
-  InlineImageProvider inlineImageProvider =
+  final AnimationBadgeProvider animationProvider = AnimationBadgeProvider();
+  final BadgeMessageProvider badgeData = BadgeMessageProvider();
+  final ImageUtils imageUtils = ImageUtils();
+  final InlineImageProvider inlineImageProvider =
       GetIt.instance<InlineImageProvider>();
-  bool isPrefixIconClicked = false;
-  int textfieldLength = 0;
-  String previousText = '';
   final TextEditingController inlineimagecontroller =
       GetIt.instance.get<InlineImageProvider>().getController();
+
+  bool isPrefixIconClicked = false;
   bool isDialInteracting = false;
-  String errorVal = "";
+  String previousText = '';
+  String _cachedText = '';
 
   @override
   void initState() {
@@ -63,8 +61,26 @@ class _HomeScreenState extends State<HomeScreen>
     });
     _startImageCaching();
     speedDialProvider = SpeedDialProvider(animationProvider);
-    super.initState();
     _tabController = TabController(length: 3, vsync: this);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    inlineimagecontroller.removeListener(handleTextChange);
+    inlineimagecontroller.removeListener(_controllerListner);
+    animationProvider.stopAnimation();
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _controllerListner() {
+    animationProvider.badgeAnimation(
+      inlineImageProvider.getController().text,
+      Converters(),
+      animationProvider.isEffectActive(InvertLEDEffect()),
+    );
   }
 
   void handleTextChange() {
@@ -73,7 +89,6 @@ class _HomeScreenState extends State<HomeScreen>
 
     if (previousText.length > currentText.length) {
       final deletionIndex = selection.baseOffset;
-
       final regex = RegExp(r'<<\d+>>');
       final matches = regex.allMatches(previousText);
 
@@ -98,21 +113,6 @@ class _HomeScreenState extends State<HomeScreen>
     }
   }
 
-  void _controllerListner() {
-    animationProvider.badgeAnimation(inlineImageProvider.getController().text,
-        Converters(), animationProvider.isEffectActive(InvertLEDEffect()));
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    inlineimagecontroller.removeListener(handleTextChange);
-    animationProvider.stopAnimation();
-    inlineImageProvider.getController().removeListener(_controllerListner);
-    _tabController.dispose();
-    super.dispose();
-  }
-
   void _setPortraitOrientation() {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
@@ -132,232 +132,208 @@ class _HomeScreenState extends State<HomeScreen>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    InlineImageProvider inlineImageProvider =
-        Provider.of<InlineImageProvider>(context);
 
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<AnimationBadgeProvider>(
-          create: (context) => animationProvider,
+          create: (_) => animationProvider,
         ),
         ChangeNotifierProvider<SpeedDialProvider>(
-          create: (context) {
-            inlineImageProvider.getController().addListener(_controllerListner);
+          create: (_) {
+            inlineimagecontroller.addListener(_controllerListner);
             return speedDialProvider;
           },
         ),
       ],
       child: DefaultTabController(
-          length: 3,
-          child: CommonScaffold(
-            index: 0,
-            title: 'Badge Magic',
-            body: SafeArea(
-              child: SingleChildScrollView(
-                physics: isDialInteracting
-                    ? const NeverScrollableScrollPhysics()
-                    : const AlwaysScrollableScrollPhysics(),
-                child: Column(
-                  children: [
-                    AnimationBadge(),
-                    Container(
-                      margin: EdgeInsets.all(15.w),
-                      child: Material(
-                        color: drawerHeaderTitle,
+        length: 3,
+        child: CommonScaffold(
+          index: 0,
+          title: 'Badge Magic',
+          scaffoldKey: const Key(homeScreenTitleKey),
+          body: SafeArea(
+            child: SingleChildScrollView(
+              physics: isDialInteracting
+                  ? const NeverScrollableScrollPhysics()
+                  : const AlwaysScrollableScrollPhysics(),
+              child: Column(
+                children: [
+                  AnimationBadge(),
+                  Container(
+                    margin: EdgeInsets.all(15.w),
+                    child: Material(
+                      color: drawerHeaderTitle,
+                      borderRadius: BorderRadius.circular(10.r),
+                      elevation: 4,
+                      child: ExtendedTextField(
+                        controller: inlineimagecontroller,
+                        specialTextSpanBuilder: ImageBuilder(),
+                        decoration: InputDecoration(
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10.r),
+                          ),
+                          prefixIcon: IconButton(
+                            onPressed: () {
+                              setState(() {
+                                isPrefixIconClicked = !isPrefixIconClicked;
+                              });
+                            },
+                            icon: const Icon(Icons.tag_faces_outlined),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderRadius:
+                                BorderRadius.all(Radius.circular(10.r)),
+                            borderSide: BorderSide(color: colorPrimary),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Visibility(
+                    visible: isPrefixIconClicked,
+                    child: Container(
+                      height: 170.h,
+                      decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(10.r),
-                        elevation: 4,
-                        child: ExtendedTextField(
-                          onChanged: (value) {},
-                          controller: inlineimagecontroller,
-                          specialTextSpanBuilder: ImageBuilder(),
-                          decoration: InputDecoration(
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(10.r),
-                            ),
-                            prefixIcon: IconButton(
-                              onPressed: () {
-                                setState(() {
-                                  isPrefixIconClicked = !isPrefixIconClicked;
-                                });
-                              },
-                              icon: const Icon(Icons.tag_faces_outlined),
-                            ),
-                            focusedBorder: OutlineInputBorder(
-                              borderRadius:
-                                  BorderRadius.all(Radius.circular(10.r)),
-                              borderSide: BorderSide(color: colorPrimary),
-                            ),
-                          ),
-                        ),
+                        color: Colors.grey[200],
                       ),
+                      margin: EdgeInsets.symmetric(horizontal: 15.w),
+                      padding: EdgeInsets.symmetric(
+                          vertical: 10.h, horizontal: 10.w),
+                      child: VectorGridView(),
                     ),
-                    Visibility(
-                        visible: isPrefixIconClicked,
-                        child: Container(
-                            height: 170.h,
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10.r),
-                                color: Colors.grey[200]),
-                            margin: EdgeInsets.symmetric(horizontal: 15.w),
-                            padding: EdgeInsets.symmetric(
-                                vertical: 10.h, horizontal: 10.w),
-                            child: VectorGridView())),
-                    TabBar(
-                      indicatorSize: TabBarIndicatorSize.tab,
-                      labelColor: Colors.black,
-                      unselectedLabelColor: mdGrey400,
-                      indicatorColor: colorPrimary,
+                  ),
+                  TabBar(
+                    indicatorSize: TabBarIndicatorSize.tab,
+                    labelColor: Colors.black,
+                    unselectedLabelColor: mdGrey400,
+                    indicatorColor: colorPrimary,
+                    controller: _tabController,
+                    splashFactory: InkRipple.splashFactory,
+                    overlayColor: WidgetStateProperty.resolveWith<Color?>(
+                      (states) => states.contains(WidgetState.pressed)
+                          ? dividerColor
+                          : null,
+                    ),
+                    tabs: const [
+                      Tab(text: 'Speed'),
+                      Tab(text: 'Animation'),
+                      Tab(text: 'Effects'),
+                    ],
+                  ),
+                  SizedBox(
+                    height: 250.h,
+                    child: TabBarView(
+                      physics: const NeverScrollableScrollPhysics(),
                       controller: _tabController,
-                      splashFactory: InkRipple.splashFactory,
-                      overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                        (Set<WidgetState> states) {
-                          if (states.contains(WidgetState.pressed)) {
-                            return dividerColor;
-                          }
-                          return null;
-                        },
-                      ),
-                      tabs: const [
-                        Tab(text: 'Speed'),
-                        Tab(text: 'Animation'),
-                        Tab(text: 'Effects'),
-                      ],
-                    ),
-                    SizedBox(
-                      height: 250.h, // Adjust the height dynamically
-                      child: TabBarView(
-                        physics: const NeverScrollableScrollPhysics(),
-                        controller: _tabController,
-                        children: [
-                          GestureDetector(
-                              onPanDown: (_) {
-                                // Enter interaction mode to stop main scrolling
-                                setState(() => isDialInteracting = true);
-                              },
-                              onPanCancel: () {
-                                // Exit interaction mode if interaction is cancelled
-                                setState(() => isDialInteracting = false);
-                              },
-                              onPanEnd: (_) {
-                                // Re-enable main scroll when done interacting
-                                setState(() => isDialInteracting = false);
-                              },
-                              child: RadialDial()),
-                          AnimationTab(),
-                          EffectTab(),
-                        ],
-                      ),
-                    ),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Container(
-                          padding: EdgeInsets.symmetric(vertical: 20.h),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              GestureDetector(
-                                onTap: () {
-                                  if (inlineimagecontroller.text
-                                      .trim()
-                                      .isEmpty) {
-                                    ToastUtils().showErrorToast(
-                                        "Please enter a message");
-                                    return;
-                                  }
-                                  logger.i(
-                                      'Save button clicked, showing dialog : ${animationProvider.isEffectActive(FlashEffect())}');
-                                  showDialog(
-                                      context: this.context,
-                                      builder: (context) {
-                                        return SaveBadgeDialog(
-                                          speed: speedDialProvider,
-                                          animationProvider: animationProvider,
-                                          textController: inlineImageProvider
-                                              .getController(),
-                                          isInverse:
-                                              animationProvider.isEffectActive(
-                                                  InvertLEDEffect()),
-                                        );
-                                      });
-                                },
-                                child: Container(
-                                  padding: EdgeInsets.symmetric(
-                                      horizontal: 33.w, vertical: 8.h),
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(2.r),
-                                    color: mdGrey400,
-                                  ),
-                                  child: const Text('Save'),
-                                ),
-                              ),
-                            ],
-                          ),
+                        GestureDetector(
+                          onPanDown: (_) =>
+                              setState(() => isDialInteracting = true),
+                          onPanCancel: () =>
+                              setState(() => isDialInteracting = false),
+                          onPanEnd: (_) =>
+                              setState(() => isDialInteracting = false),
+                          child: RadialDial(),
                         ),
-                        SizedBox(
-                          width: 100.w,
-                        ),
-                        Container(
-                          padding: EdgeInsets.symmetric(vertical: 20.h),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              GestureDetector(
-                                onTap: () {
-                                  badgeData.checkAndTransfer(
-                                      inlineImageProvider.getController().text,
-                                      animationProvider
-                                          .isEffectActive(FlashEffect()),
-                                      animationProvider
-                                          .isEffectActive(MarqueeEffect()),
-                                      animationProvider
-                                          .isEffectActive(InvertLEDEffect()),
-                                      speedDialProvider.getOuterValue(),
-                                      modeValueMap[animationProvider
-                                          .getAnimationIndex()],
-                                      null,
-                                      false);
-                                },
-                                child: Container(
-                                  padding: EdgeInsets.symmetric(
-                                      horizontal: 20.w, vertical: 8.h),
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(2.r),
-                                    color: mdGrey400,
-                                  ),
-                                  child: const Text('Transfer'),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
+                        AnimationTab(),
+                        EffectTab(),
                       ],
-                    )
-                  ],
-                ),
+                    ),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Container(
+                        padding: EdgeInsets.symmetric(vertical: 20.h),
+                        child: GestureDetector(
+                          onTap: () {
+                            if (inlineimagecontroller.text.trim().isEmpty) {
+                              ToastUtils()
+                                  .showErrorToast("Please enter a message");
+                              return;
+                            }
+                            showDialog(
+                              context: context,
+                              builder: (context) {
+                                return SaveBadgeDialog(
+                                  speed: speedDialProvider,
+                                  animationProvider: animationProvider,
+                                  textController: inlineimagecontroller,
+                                  isInverse: animationProvider
+                                      .isEffectActive(InvertLEDEffect()),
+                                );
+                              },
+                            );
+                          },
+                          child: Container(
+                            padding: EdgeInsets.symmetric(
+                                horizontal: 33.w, vertical: 8.h),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(2.r),
+                              color: mdGrey400,
+                            ),
+                            child: const Text('Save'),
+                          ),
+                        ),
+                      ),
+                      SizedBox(width: 100.w),
+                      Container(
+                        padding: EdgeInsets.symmetric(vertical: 20.h),
+                        child: GestureDetector(
+                          onTap: () {
+                            badgeData.checkAndTransfer(
+                              inlineimagecontroller.text,
+                              animationProvider.isEffectActive(FlashEffect()),
+                              animationProvider.isEffectActive(MarqueeEffect()),
+                              animationProvider
+                                  .isEffectActive(InvertLEDEffect()),
+                              speedDialProvider.getOuterValue(),
+                              modeValueMap[
+                                  animationProvider.getAnimationIndex()],
+                              null,
+                              false,
+                            );
+                          },
+                          child: Container(
+                            padding: EdgeInsets.symmetric(
+                                horizontal: 20.w, vertical: 8.h),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(2.r),
+                              color: mdGrey400,
+                            ),
+                            child: const Text('Transfer'),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ),
-            scaffoldKey: const Key(homeScreenTitleKey),
-          )),
+          ),
+        ),
+      ),
     );
   }
 
   @override
   bool get wantKeepAlive => true;
-
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    super.didChangeAppLifecycleState(state);
-    if (state == AppLifecycleState.resumed) {
-      inlineimagecontroller.clear();
-      previousText = '';
-      animationProvider.stopAllAnimations();
-      animationProvider.initializeAnimation();
-      if (mounted) setState(() {});
-    } else if (state == AppLifecycleState.paused ||
-        state == AppLifecycleState.inactive) {
+    if (state == AppLifecycleState.paused) {
+      _cachedText = inlineimagecontroller.text;
       animationProvider.stopAnimation();
+    } else if (state == AppLifecycleState.resumed) {
+      if (inlineimagecontroller.text.trim().isEmpty &&
+          _cachedText.trim().isNotEmpty) {
+        inlineimagecontroller.text = _cachedText;
+      }
+      animationProvider.badgeAnimation(
+        inlineimagecontroller.text,
+        Converters(),
+        animationProvider.isEffectActive(InvertLEDEffect()),
+      );
     }
   }
 }


### PR DESCRIPTION
fixes: #1307 

Description:

When the app is sent to the background or resumed from the background, the virtual badge preview stops updating. The text and animation freeze or disappear, and they do not resume automatically. This breaks the expected continuous display behavior and often requires restarting the app to restore proper functionality.

Steps to Reproduce:

1. Open the app.
2. Enter text in the text field to start the badge preview.
3. Minimize the app or switch to another app.
4. Return to the app (resume it).

Observed Behavior:

1. The virtual badge preview disappears or stops animating.
2. The previously entered text is still in the text field but no animation resumes.
3. The UI becomes unresponsive in terms of badge updates until the app is restarted.

Expected Behavior:

All UI elements should remain visible and update properly based on user interaction. Nothing should disappear or go blank randomly.

## Summary by Sourcery

Fix Homescreen badge preview display by handling app lifecycle events and ensuring animation resumes correctly after backgrounding

Bug Fixes:
- Prevent virtual badge preview from freezing or disappearing after the app is sent to the background by caching text and restarting the animation on resume

Enhancements:
- Add WidgetsBindingObserver to HomeScreenState to respond to AppLifecycleState changes
- Cache text input on pause and restore it on resume before re-triggering badge animation
- Consolidate text controller listener setup and teardown and remove duplicate listener methods
- Clean up imports, streamline provider initialization, and add a scaffold key for the HomeScreen