### PR TITLE
chore: rename branch in update-release action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -230,8 +230,8 @@ jobs:
       - name: Create and Upload Assets
         run: |
           echo "${{ needs.common.outputs.VERSION_CODE }}" > ./versionCode.txt
-          git clone --branch=apk https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} apk
-          gh release upload ${{ steps.run-release-drafter.outputs.tag_name }} apk/badge-magic-flutter_app-release.apk ./versionCode.txt --clobber
+          git clone --branch=app https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} app
+          gh release upload ${{ steps.run-release-drafter.outputs.tag_name }} app/badge-magic-development-release.apk ./versionCode.txt --clobber
 
   screenshots-android:
     name: Screenshots (Android)


### PR DESCRIPTION
Renames _apk_ branch to _app_ in the _update-release_ action.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Rename the branch and asset path in the update-release GitHub action to use ‘app’ instead of ‘apk’.

CI:
- Change clone branch from ‘apk’ to ‘app’ in the update-release action
- Update release upload path to ‘app/badge-magic-development-release.apk’