### PR TITLE
fix: Go to HomeScreen after Saving a Clipart

### DIFF
--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -13,12 +13,13 @@ class DrawBadge extends StatefulWidget {
   final bool? isSavedCard;
   final bool? isSavedClipart;
   final List<List<int>>? badgeGrid;
-  const DrawBadge(
-      {super.key,
-      this.filename,
-      this.isSavedCard = false,
-      this.isSavedClipart = false,
-      this.badgeGrid});
+  const DrawBadge({
+    super.key,
+    this.filename,
+    this.isSavedCard = false,
+    this.isSavedClipart = false,
+    this.badgeGrid,
+  });
 
   @override
   State<DrawBadge> createState() => _DrawBadgeState();
@@ -59,7 +60,7 @@ class _DrawBadgeState extends State<DrawBadge> {
     return WillPopScope(
       onWillPop: () async {
         _resetPortraitOrientation();
-        return true; // Allows back navigation
+        return true;
       },
       child: CommonScaffold(
         index: 1,
@@ -79,9 +80,7 @@ class _DrawBadgeState extends State<DrawBadge> {
                   children: [
                     Column(
                       children: [
-                        SizedBox(
-                          width: 100,
-                        ),
+                        const SizedBox(width: 100),
                         BMBadge(
                           providerInit: (provider) => drawToggle = provider,
                           badgeGrid: widget.badgeGrid
@@ -163,38 +162,43 @@ class _DrawBadgeState extends State<DrawBadge> {
                           ),
                         ),
                         TextButton(
-                          onPressed: () {
-                            List<List<int>> badgeGrid = drawToggle
-                                .getDrawViewGrid()
-                                .map((e) => e.map((e) => e ? 1 : 0).toList())
-                                .toList();
-                            List<String> hexString =
-                                Converters.convertBitmapToLEDHex(
-                                    badgeGrid, false);
+                          onPressed: () async {
+                            try {
+                              List<List<int>> badgeGrid = drawToggle
+                                  .getDrawViewGrid()
+                                  .map((e) => e.map((e) => e ? 1 : 0).toList())
+                                  .toList();
+                              List<String> hexString =
+                                  Converters.convertBitmapToLEDHex(
+                                      badgeGrid, false);
 
-                            if (widget.isSavedCard!) {
-                              fileHelper.updateBadgeText(
-                                  widget.filename!, hexString);
-                            } else if (widget.isSavedClipart!) {
-                              fileHelper.updateClipart(
-                                  widget.filename!, badgeGrid);
-                            } else {
-                              fileHelper
-                                  .saveImage(drawToggle.getDrawViewGrid());
+                              if (widget.isSavedCard!) {
+                                await fileHelper.updateBadgeText(
+                                    widget.filename!, hexString);
+                              } else if (widget.isSavedClipart!) {
+                                await fileHelper.updateClipart(
+                                    widget.filename!, badgeGrid);
+                              } else {
+                                await fileHelper
+                                    .saveImage(drawToggle.getDrawViewGrid());
+                              }
+
+                              await fileHelper.generateClipartCache();
+
+                              ToastUtils()
+                                  .showToast("Clipart Saved Successfully");
+
+                              await Future.delayed(
+                                  const Duration(milliseconds: 800));
+
+                              if (mounted) {
+                                Navigator.of(context)
+                                    .popUntil((route) => route.isFirst);
+                              }
+                            } catch (e) {
+                              ToastUtils().showToast(
+                                  "Failed to save badge: ${e.toString()}");
                             }
-
-                            fileHelper.generateClipartCache();
-
-                            // Show toast first
-                            ToastUtils()
-                                .showToast("Clipart Saved Successfully");
-
-                            // Delay redirection slightly to ensure toast is visible
-                            Future.delayed(const Duration(milliseconds: 800),
-                                () {
-                              Navigator.of(context)
-                                  .popUntil((route) => route.isFirst);
-                            });
                           },
                           child: const Column(
                             children: [

--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -171,19 +171,30 @@ class _DrawBadgeState extends State<DrawBadge> {
                             List<String> hexString =
                                 Converters.convertBitmapToLEDHex(
                                     badgeGrid, false);
-                            widget.isSavedCard!
-                                ? fileHelper.updateBadgeText(
-                                    widget.filename!,
-                                    hexString,
-                                  )
-                                : widget.isSavedClipart!
-                                    ? fileHelper.updateClipart(
-                                        widget.filename!, badgeGrid)
-                                    : fileHelper.saveImage(
-                                        drawToggle.getDrawViewGrid());
+
+                            if (widget.isSavedCard!) {
+                              fileHelper.updateBadgeText(
+                                  widget.filename!, hexString);
+                            } else if (widget.isSavedClipart!) {
+                              fileHelper.updateClipart(
+                                  widget.filename!, badgeGrid);
+                            } else {
+                              fileHelper
+                                  .saveImage(drawToggle.getDrawViewGrid());
+                            }
+
                             fileHelper.generateClipartCache();
+
+                            // Show toast first
                             ToastUtils()
                                 .showToast("Clipart Saved Successfully");
+
+                            // Delay redirection slightly to ensure toast is visible
+                            Future.delayed(const Duration(milliseconds: 800),
+                                () {
+                              Navigator.of(context)
+                                  .popUntil((route) => route.isFirst);
+                            });
                           },
                           child: const Column(
                             children: [


### PR DESCRIPTION
Fixes #1372<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes 
- After Clicking on Save in Saved Clipart it saves and redirects to homescreen.<!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

https://github.com/user-attachments/assets/be92c7e1-7179-4799-a1a4-21831fd24372



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Implement explicit save logic for cliparts and ensure the app navigates back to the HomeScreen after saving, with toast feedback and a slight delay for visibility.

Bug Fixes:
- Navigate to the HomeScreen after saving a clipart

Enhancements:
- Refactor nested ternary save calls into an explicit if-else block for clarity
- Display a "Clipart Saved Successfully" toast and delay navigation by 800ms to allow the toast to be seen