### PR TITLE
chore: push only release APKs to apk branch 

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -131,8 +131,8 @@ jobs:
 
           echo "Copying new build files"
 
-          find ../build/app/outputs/flutter-apk -type f \( -name '*.apk' -o -name '*.aab' \) -exec cp -v {} . \;
-          find ../build/app/outputs/bundle -type f \( -name '*.apk' -o -name '*.aab' \) -exec cp -v {} . \;
+          find ../build/app/outputs/flutter-apk -type f \( -name '*release.apk' -o -name '*release.aab' \) -exec cp -v {} . \;
+          find ../build/app/outputs/bundle -type f \( -name '*release.apk' -o -name '*release.aab' \) -exec cp -v {} . \;
 
           ls
 


### PR DESCRIPTION
#1408 
-Fixes the failing CI <!-- Add here what changes were made in this pull request and if possible provide links. -->
