### PR TITLE
chore: improve screenshot workflows

### DIFF
--- a/.github/actions/screenshot-ipad/action.yml
+++ b/.github/actions/screenshot-ipad/action.yml
@@ -1,10 +1,6 @@
-name: "iOS Screenshots Workflow"
+name: "iPad Screenshots Workflow"
 
 inputs:
-  IPHONE_DEVICE_MODEL:
-    description: 'Model of the iPhone device to be used when running tests'
-    required: false
-    default: iPhone 16 Pro Max
   IPAD_DEVICE_MODEL:
     description: 'Model of the iPad device to be used when running tests'
     required: false
@@ -26,27 +22,17 @@ runs:
         flutter pub get
         pod install --repo-update
 
-    - name: Create iPhone Simulator
-      uses: futureware-tech/simulator-action@v4
-      with:
-        model: ${{ inputs.IPHONE_DEVICE_MODEL }}
-        wait_for_boot: true
-
     - name: Create iPad Simulator
+      id: ipad_sim
       uses: futureware-tech/simulator-action@v4
       with:
         model: ${{ inputs.IPAD_DEVICE_MODEL }}
         wait_for_boot: true
 
-    - name: Capture iPhone Screenshots
-      shell: bash
-      run: |
-        DEVICE_NAME="${{ inputs.IPHONE_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPHONE_DEVICE_MODEL }}"
-
     - name: Capture iPad Screenshots
       shell: bash
       run: |
-        DEVICE_NAME="${{ inputs.IPAD_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPAD_DEVICE_MODEL }}"
+        DEVICE_NAME="${{ inputs.IPAD_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ steps.ipad_sim.outputs.udid }}"
 
     - name: Update Fastlane Metadata
       if: ${{ github.event_name == 'push' }}
@@ -59,7 +45,7 @@ runs:
         git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
         cd fastlane
         
-        rm -rf screenshots/*
+        rm -rf screenshots/iPad*
         cp -r ../../screenshots/. screenshots/
         
         # Force push to fastlane branch
@@ -73,5 +59,5 @@ runs:
     - name: Upload Screenshots
       uses: actions/upload-artifact@v4
       with:
-        name: iOS Screenshots
+        name: iPad Screenshots
         path: screenshots/*

--- a/.github/actions/screenshot-iphone/action.yml
+++ b/.github/actions/screenshot-iphone/action.yml
@@ -1,0 +1,63 @@
+name: "iPhone Screenshots Workflow"
+
+inputs:
+  IPHONE_DEVICE_MODEL:
+    description: 'Model of the iPhone device to be used when running tests'
+    required: false
+    default: iPhone 16 Pro Max
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        cache: true
+        flutter-version-file: pubspec.yaml
+
+    - name: Update Podfile
+      shell: bash
+      run: |
+        cd ./iOS
+        flutter pub get
+        pod install --repo-update
+
+    - name: Create iPhone Simulator
+      id: iphone_sim
+      uses: futureware-tech/simulator-action@v4
+      with:
+        model: ${{ inputs.IPHONE_DEVICE_MODEL }}
+        wait_for_boot: true
+
+    - name: Capture iPhone Screenshots
+      shell: bash
+      run: |
+        DEVICE_NAME="${{ inputs.IPHONE_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ steps.iphone_sim.outputs.udid }}"
+
+    - name: Update Fastlane Metadata
+      if: ${{ github.event_name == 'push' }}
+      shell: bash
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        
+        cd ./iOS
+        git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+        cd fastlane
+        
+        rm -rf screenshots/iPhone*
+        cp -r ../../screenshots/. screenshots/
+        
+        # Force push to fastlane branch
+        git checkout --orphan temporary
+        git add --all .
+        git commit -am "[Auto] Update screenshots ($(date +%Y-%m-%d.%H:%M:%S))"
+        git branch -D fastlane-ios
+        git branch -m fastlane-ios
+        git push --force origin fastlane-ios
+
+    - name: Upload Screenshots
+      uses: actions/upload-artifact@v4
+      with:
+        name: iPhone Screenshots
+        path: screenshots/*

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ "development" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ANDROID_EMULATOR_API: 34
   ANDROID_EMULATOR_ARCH: x86_64
@@ -58,6 +62,7 @@ jobs:
   screenshots-android:
     name: Screenshots (Android)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -67,9 +72,10 @@ jobs:
           ANDROID_EMULATOR_API: ${{ env.ANDROID_EMULATOR_API }}
           ANDROID_EMULATOR_ARCH: ${{ env.ANDROID_EMULATOR_ARCH }}
 
-  screenshots-ios:
-    name: Screenshots (iOS)
+  screenshots-iphone:
+    name: Screenshots (iPhone)
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1.6.0
@@ -78,9 +84,25 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: iOS Screenshot Workflow
-        uses: ./.github/actions/screenshot-ios
+      - name: iPhone Screenshot Workflow
+        uses: ./.github/actions/screenshot-iphone
         with:
           IPHONE_DEVICE_MODEL: ${{ env.IPHONE_DEVICE_MODEL }}
+  
+  screenshots-ipad:
+    name: Screenshots (iPad)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest-stable
+
+      - uses: actions/checkout@v4
+
+      - name: iPad Screenshot Workflow
+        uses: ./.github/actions/screenshot-ipad
+        with:
           IPAD_DEVICE_MODEL: ${{ env.IPAD_DEVICE_MODEL }}
       

--- a/.github/workflows/pull_request_comment.yml
+++ b/.github/workflows/pull_request_comment.yml
@@ -47,17 +47,29 @@ jobs:
 
             fs.writeFileSync('${{github.workspace}}/androidScreenshots.zip', Buffer.from(downloadAndroidScreenshots.data));
 
-            var iosScreenshots = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "iOS Screenshots"
+            var iPadScreenshots = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "iPad Screenshots"
             })[0];
-            var downloadIosScreenshots = await github.rest.actions.downloadArtifact({
+            var downloadiPadScreenshots = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               artifact_id: iosScreenshots.id,
+               artifact_id: iPadScreenshots.id,
                archive_format: 'zip',
             });
 
-            fs.writeFileSync('${{github.workspace}}/iosScreenshots.zip', Buffer.from(downloadIosScreenshots.data));
+            fs.writeFileSync('${{github.workspace}}/iPadScreenshots.zip', Buffer.from(downloadiPadScreenshots.data));
+
+            var iPhoneScreenshots = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "iPhone Screenshots"
+            })[0];
+            var downloadiPhoneScreenshots = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: iPhoneScreenshots.id,
+               archive_format: 'zip',
+            });
+
+            fs.writeFileSync('${{github.workspace}}/iPhoneScreenshots.zip', Buffer.from(downloadiPhoneScreenshots.data));
 
       - name: Unzip Artifacts
         shell: bash
@@ -65,7 +77,8 @@ jobs:
           unzip pr.zip
           mkdir screenshots
           unzip androidScreenshots.zip -d screenshots/
-          unzip iosScreenshots.zip -d screenshots/
+          unzip iPadScreenshots.zip -d screenshots/
+          unzip iPhoneScreenshots.zip -d screenshots/
         
       - name: Fetch PR Number
         id: fetch-pr-number
@@ -135,6 +148,8 @@ jobs:
             var statusText = `Build successful. APKs to test: ${artifact_url}.`;
 
             var androidScreenshots = `
+            <details>
+            <summary>Android Screenshots</summary>
             <table>
               <tr>
                 <td><img src="https://github.com/fossasia/badgemagic-app/blob/pr-screenshots/${issue_number}_Pixel_6-1_home_screen.png?raw=true" width="1080"/></td>
@@ -150,9 +165,12 @@ jobs:
                 </td>
               </tr>
             </table>
+            </details>
             `;
 
             var iPhoneScreenshots = `
+            <details>
+            <summary>iPhone Screenshots</summary>
             <table>
               <tr>
                 <td><img src="https://github.com/fossasia/badgemagic-app/blob/pr-screenshots/${issue_number}_iPhone_16_Pro_Max-1_home_screen.png?raw=true" width="1080"/></td>
@@ -168,9 +186,12 @@ jobs:
                 </td>
               </tr>
             </table>
+            </details>
             `;
 
             var iPadScreenshots = `
+            <details>
+            <summary>iPad Screenshots</summary>
             <table>
               <tr>
                 <td><img src="https://github.com/fossasia/badgemagic-app/blob/pr-screenshots/${issue_number}_iPad_Pro_13-inch_(M4)-1_home_screen.png?raw=true" width="1080"/></td>
@@ -186,19 +207,16 @@ jobs:
                 </td>
               </tr>
             </table>
+            </details>
             `;
 
             const body = `
             ## Build Status
             ${statusText}
 
-            ## Screenshots (Android)
+            ## Screenshots
             ${androidScreenshots}
-
-            ## Screenshots (iPhone)
             ${iPhoneScreenshots}
-
-            ## Screenshots (iPad)
             ${iPadScreenshots}
             `;
             
@@ -245,13 +263,7 @@ jobs:
             ## Build Status
             _Build workflow failed. Please check the logs for more information._
 
-            ## Screenshots (Android)
-            _Not able to fetch screenshots._
-
-            ## Screenshots (iPhone)
-            _Not able to fetch screenshots._
-
-            ## Screenshots (iPad)
+            ## Screenshots
             _Not able to fetch screenshots._
             `;
             

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,16 +10,6 @@ env:
   ANDROID_EMULATOR_ARCH: x86_64
   IPHONE_DEVICE_MODEL: iPhone 16 Pro Max
   IPAD_DEVICE_MODEL: iPad Pro 13-inch (M4)
-  BARECHECK_GITHUB_APP_TOKEN: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
-  ENCRYPTED_F10B5E0E5262_IV: ${{ secrets.ENCRYPTED_F10B5E0E5262_IV }}
-  ENCRYPTED_F10B5E0E5262_KEY: ${{ secrets.ENCRYPTED_F10B5E0E5262_KEY }}
-  ENCRYPTED_IOS_IV: ${{ secrets.ENCRYPTED_IOS_IV }}
-  ENCRYPTED_IOS_KEY: ${{ secrets.ENCRYPTED_IOS_KEY }}
-  STORE_PASS: ${{ secrets.STORE_PASS }}
-  ALIAS: ${{ secrets.ALIAS }}
-  KEY_PASS: ${{ secrets.KEY_PASS }}
-  MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-  MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
 
 jobs:
   common:
@@ -236,6 +226,7 @@ jobs:
   screenshots-android:
     name: Screenshots (Android)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -245,19 +236,36 @@ jobs:
           ANDROID_EMULATOR_API: ${{ env.ANDROID_EMULATOR_API }}
           ANDROID_EMULATOR_ARCH: ${{ env.ANDROID_EMULATOR_ARCH }}
 
-  screenshots-ios:
-    name: Screenshots (iOS)
+  screenshots-iphone:
+    name: Screenshots (iPhone)
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: latest-stable
 
-      - name: iOS Screenshot Workflow
-        uses: ./.github/actions/screenshot-ios
+      - uses: actions/checkout@v4
+
+      - name: iPhone Screenshot Workflow
+        uses: ./.github/actions/screenshot-iphone
         with:
           IPHONE_DEVICE_MODEL: ${{ env.IPHONE_DEVICE_MODEL }}
+  
+  screenshots-ipad:
+    name: Screenshots (iPad)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest-stable
+
+      - uses: actions/checkout@v4
+
+      - name: iPad Screenshot Workflow
+        uses: ./.github/actions/screenshot-ipad
+        with:
           IPAD_DEVICE_MODEL: ${{ env.IPAD_DEVICE_MODEL }}


### PR DESCRIPTION
## Summary by Sourcery

Separate the iOS screenshot pipeline into distinct iPhone and iPad workflows, introduce a dedicated iPad composite action, add timeouts and concurrency controls, and enhance the PR comment job to download and embed Android, iPhone, and iPad screenshots in collapsible sections.

New Features:
- Add a new composite GitHub Action for capturing iPad screenshots.

Enhancements:
- Rename the existing screenshot-ios action to screenshot-iphone and extract iPad logic into its own action.
- Split screenshot jobs into screenshots-iphone and screenshots-ipad in both push and pull_request workflows with explicit Xcode setup and timeout-minutes.
- Refactor the PR comment workflow to download, unzip, and display Android, iPhone, and iPad artifacts in expandable details blocks.

CI:
- Remove unused secret environment variables from the push workflow.
- Add concurrency cancellation to the pull_request workflow to prevent overlapping runs.