### PR TITLE
chore: bumped gradle version

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip


### PR DESCRIPTION
the gradle version is bumped after merging this one the CI will re-run the workflow, and the build should succeed.

## Summary by Sourcery

Improve badge scanning configurability with persistent scan settings, refactor key UI components and providers for cleaner flows, and bump Gradle version to 8.13

New Features:
- Add BadgeScanProvider with shared_preferences persistence for badge scan mode and allowed badge names
- Enable badge scan configuration in SettingsScreen and ScanState to filter devices by mode and names
- Provide a reusable BadgeScanSettingsWidget for scan settings UI

Enhancements:
- Refactor HomeScreen to remove legacy editing, simplify tab structure, add lifecycle handling, and clean up resource management
- Streamline SaveBadgeCard UI and navigation, replacing custom edit flow with DrawBadgeScreen
- Simplify AnimationBadgeProvider by removing unused animations and legacy transfer handlers
- Update BadgeMessageProvider to accept BuildContext and integrate scan provider into data transfer flow
- Clean up imports, dependency injection, and obsolete code across multiple widgets

Build:
- Bump Android Gradle wrapper to Gradle 8.13

Chores:
- Add shared_preferences dependency