### PR TITLE
fix: macos transfer

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #1442

## Changes 
- Enabled Bluetooth usage permission on macOS.
- Transfer functionality now works after Bluetooth is enabled.

## New Issue Observed
- On macOS, the first click on Transfer only initializes Bluetooth and shows "unsupported platform".
- From the second click onwards, the transfer works correctly.
- This needs a follow-up fix for Bluetooth initialization handling.

## Screenshots / Recordings  
https://github.com/user-attachments/assets/e455c839-f31f-49c3-ac6a-174e600f750a

## Summary by Sourcery

Enable Bluetooth usage permission in macOS entitlements to restore transfer functionality after authorization and resolve issue #1442, while noting a first-click initialization glitch remains.

Bug Fixes:
- Restore macOS transfer functionality by enabling Bluetooth permission

Build:
- Add Bluetooth usage entitlement to macOS Debug and Release profiles