### PR TITLE
feat: add auto-reply workflow for assignment requests

### DIFF
--- a/.github/workflows/auto-reply.yml
+++ b/.github/workflows/auto-reply.yml
@@ -1,0 +1,30 @@
+name: Auto Reply to Assign Requests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  auto-reply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check for assign keywords
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const keywords = require("./keywords.json");
+            const comment = context.payload.comment.body.toLowerCase();
+            const rx = /(?:assign\s*(?:me|this\s*to\s*me|pls|plz)|(?:pls|plz)\s*assign(?:\s*me)?|please\s*(?:assign|let\s*me\s*work\s*on\s*this)|kindly\s*assign(?:\s*this\s*to\s*me)?|can\s*i\s*(?:work\s*on|take|try|pick\s*this\s*up)|may\s*i\s*work\s*on\s*this|could\s*you\s*assign\s*me|would\s*you\s*assign\s*me|can\s*you\s*(?:please\s*)?assign(?:\s*this\s*to\s*me)?|i\s*(?:want\s*to|would\s*like\s*to|’d\s*like\s*to|will|'ll|can)\s*(?:work\s*on|fix|take|pick\s*this\s*up)|let\s*me\s*(?:handle|take\s*this\s*one?|pick\s*this\s*up)|wanna\s*work\s*on\s*this|lemme\s*take\s*this|dibs(?:\s*on\s*this)?|me\s*please)/i;
+
+            if (rx.test(comment)) {
+              const issueNumber = context.payload.issue.number;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: "Please go ahead and create a PR when you are ready. We do not formally assign issues. Contributors are free to pick up any open issue based on their availability. You can open a PR or even a draft PR to let others know that you’re working on it."
+              });
+            }


### PR DESCRIPTION
feat: add auto-reply GitHub Action for assignment requests
This workflow analyzes issue comments and automatically replies when a contributor asks to be assigned to an issue.
Fixes # 1363

## Changes 
Added a new workflow (.github/workflows/auto-reply.yml)
Detects assignment requests in issue comments using regex (e.g. “please assign”, “can I work on this”, “assign me”, etc.)
Automatically replies with a standard message:
“Please go ahead and create a PR when you are ready. We do not formally assign issues. Contributors are free to pick up any open issue based on their availability. You can open a PR or even a draft PR to let others know that you’re working on it.”

This saves time for moderators by reducing repetitive responses to assignment requests.
The code uses simple regex to track the commentors message and check for keywords such as "please assign, can i work on this.."

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x ] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x ] **No end of file edits**: No modifications done at end of resource files.
- [x ] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x ] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Introduce an automated workflow that listens for assignment requests in issue comments and replies with a standard message clarifying that contributors can pick any open issue and should open a PR instead of relying on formal assignment.

New Features:
- Add GitHub Actions workflow to automatically reply to issue assignment requests

Enhancements:
- Use a regex-based matcher to detect various assignment request phrases and post a standardized guidance comment