### PR TITLE
feat: add auto-reply workflow for assignment requests

### DIFF
--- a/.github/workflows/auto-reply.yml
+++ b/.github/workflows/auto-reply.yml
@@ -20,9 +20,10 @@ jobs:
           script: |
             const comment = context.payload.comment.body.toLowerCase();
             const author = context.payload.comment.user.login;
+            const userType = context.payload.comment.user.type;
 
             // Skip bot comments (including this workflow)
-            if (author.endsWith("[bot]")) {
+            if (author.endsWith("[bot]") || userType === "Bot") {
               return;
             }
 

--- a/.github/workflows/auto-reply.yml
+++ b/.github/workflows/auto-reply.yml
@@ -1,0 +1,43 @@
+name: Auto Reply to Assign Requests
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  auto-reply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check for assign keywords
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const comment = context.payload.comment.body.toLowerCase();
+            const author = context.payload.comment.user.login;
+
+            // Skip bot comments (including this workflow)
+            if (author.endsWith("[bot]")) {
+              return;
+            }
+
+            const rx = /(?:assign\s*(?:me|this\s*to\s*me|pls|plz)|(?:pls|plz)\s*assign(?:\s*me)?|please\s*(?:assign|let\s*me\s*work\s*on\s*this)|kindly\s*assign(?:\s*this\s*to\s*me)?|can\s*i\s*(?:work\s*on|take|try|pick\s*this\s*up)|may\s*i\s*work\s*on\s*this|could\s*you\s*assign\s*me|would\s*you\s*assign\s*me|can\s*you\s*(?:please\s*)?assign(?:\s*this\s*to\s*me)?|i\s*(?:want\s*to|would\s*like\s*to|’d\s*like\s*to|will|'ll|can)\s*(?:work\s*on|fix|take|pick\s*this\s*up)|let\s*me\s*(?:handle|take\s*this\s*one?|pick\s*this\s*up)|wanna\s*work\s*on\s*this|lemme\s*take\s*this|dibs(?:\s*on\s*this)?|me\s*please)/i;
+
+            if (rx.test(comment)) {
+              const issue = context.payload.issue || context.payload.pull_request;
+              if (!issue) {
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: "Please go ahead and create a PR when you are ready. We do not formally assign issues. Contributors are free to pick up any open issue based on their availability. You can open a PR or even a draft PR to let others know that you’re working on it."
+              });
+            }


### PR DESCRIPTION
Fixes #1363 
## Changes 
Added a new workflow (.github/workflows/auto-reply.yml)
Detects assignment requests in issue comments using regex (e.g. “please assign”, “can I work on this”, “assign me”, etc.)
Automatically replies with a standard message:
“Please go ahead and create a PR when you are ready. We do not formally assign issues. Contributors are free to pick up any open issue based on their availability. You can open a PR or even a draft PR to let others know that you’re working on it.”

This saves time for moderators by reducing repetitive responses to assignment requests.
The code uses simple regex to track the commentors message and check for keywords such as "please assign, can i work on this.."

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x ] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ x] **No end of file edits**: No modifications done at end of resource files.
- [ x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [ x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

CI:
- Add a GitHub Actions workflow (.github/workflows/auto-reply.yml) that detects assignment requests via regex in issue comments and posts a standard auto-reply