### PR TITLE
Revert "fix: created two build versions "

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -38,7 +38,7 @@ runs:
         cache: true
         flutter-version-file: pubspec.yaml
       
-    - name: Build preApi30 APK/AAB
+    - name: Build Android APK/AAB
       shell: bash
       env:
         STORE_PASS: ${{ inputs.STORE_PASS }}
@@ -47,29 +47,13 @@ runs:
         VERSION_NAME: ${{inputs.VERSION_NAME}}
         VERSION_CODE: ${{inputs.VERSION_CODE}}
       run: |
-        flutter build apk --flavor preApi30 --debug --build-name $VERSION_NAME --build-number $VERSION_CODE
-        flutter build apk --flavor preApi30 --build-name $VERSION_NAME --build-number $VERSION_CODE
-        flutter build appbundle --flavor preApi30 --build-name $VERSION_NAME --build-number $VERSION_CODE
+        flutter build apk --debug --build-name $VERSION_NAME --build-number $VERSION_CODE
+        flutter build apk --build-name $VERSION_NAME --build-number $VERSION_CODE
+        flutter build appbundle --build-name $VERSION_NAME --build-number $VERSION_CODE
 
-    - name: Build postApi30 APK/AAB
-      shell: bash
-      env:
-        STORE_PASS: ${{ inputs.STORE_PASS }}
-        ALIAS: ${{ inputs.ALIAS }}
-        KEY_PASS: ${{ inputs.KEY_PASS }}
-        VERSION_NAME: ${{inputs.VERSION_NAME}}
-        VERSION_CODE: ${{inputs.VERSION_CODE}}
-      run: |
-        flutter build apk --flavor postApi30 --debug --build-name $VERSION_NAME --build-number $VERSION_CODE
-        flutter build apk --flavor postApi30 --build-name $VERSION_NAME --build-number $VERSION_CODE
-        flutter build appbundle --flavor postApi30 --build-name $VERSION_NAME --build-number $VERSION_CODE
-
-    - name: Store APK files
+    - name: Store APK file
       uses: actions/upload-artifact@v4
       with:
         name: apk-files
         path: |
-          build/app/outputs/flutter-apk/app-preapi30-debug.apk
-          build/app/outputs/flutter-apk/app-preapi30-release.apk
-          build/app/outputs/flutter-apk/app-postapi30-debug.apk
-          build/app/outputs/flutter-apk/app-postapi30-release.apk
+          build/app/outputs/flutter-apk/app-debug.apk

--- a/.github/actions/screenshot-android/action.yml
+++ b/.github/actions/screenshot-android/action.yml
@@ -55,14 +55,7 @@ runs:
         cache: true
         flutter-version-file: pubspec.yaml
 
-    - name: Create Android Screenshots (preApi30)
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: ${{ inputs.ANDROID_EMULATOR_API }}
-        arch: ${{ inputs.ANDROID_EMULATOR_ARCH }}
-        script: flutter drive --flavor preApi30 --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d emulator
-
-    - name: Create Android Screenshots (postApi30)
+    - name: Create Android Screenshots
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ inputs.ANDROID_EMULATOR_API }}
@@ -73,7 +66,7 @@ runs:
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: |
-          DEVICE_NAME="Pixel 6" flutter drive --flavor postApi30 --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d emulator
+          DEVICE_NAME="Pixel 6" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d emulator
 
     - name: Update Fastlane Metadata
       if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,26 +23,7 @@ jobs:
 
       - name: Common Workflow
         uses: ./.github/actions/common
-
-      - name: Build preApi30 APK
-        run: flutter build apk --flavor preApi30 -t lib/main.dart
-
-      - name: Build postApi30 APK
-        run: flutter build apk --flavor postApi30 -t lib/main.dart
-
-      - name: Upload preApi30 APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: app-preapi30-release.apk
-          path: build/app/outputs/flutter-apk/app-preapi30-release.apk
-
-      - name: Upload postApi30 APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: app-postapi30-release.apk
-          path: build/app/outputs/flutter-apk/app-postapi30-release.apk
-
-
+        
       - name: Hydrate and Update Version
         id: flutter-version
         run: |

--- a/README.md
+++ b/README.md
@@ -155,31 +155,6 @@ For this mode it is required that both the workstation and the device are on the
 
 Enable Wireless debugging as per the [documentation](https://developer.android.com/tools/adb#wireless-android11-command-line), then **pair** `adb pair <IP>:<PORT>` and **connect** `adb connect <IP>:<PORT>` and you should be able to find your device via `adb devices`.
 
-## Building for Android (API Flavors)
-
-This project uses product flavors to support both pre-Android 11 and Android 11+ devices. **You must specify a flavor when building or running for Android!**
-
-- **For Android 10 and below:**
-  ```sh
-  flutter build apk --flavor preApi30 -t lib/main.dart
-  flutter run --flavor preApi30 -t lib/main.dart
-  ```
-  Output: `build/app/outputs/flutter-apk/app-preapi30-release.apk`
-
-- **For Android 11 and above:**
-  ```sh
-  flutter build apk --flavor postApi30 -t lib/main.dart
-  flutter run --flavor postApi30 -t lib/main.dart
-  ```
-  Output: `build/app/outputs/flutter-apk/app-postapi30-release.apk`
-
-If you do not specify a flavor, the build will fail due to missing `minSdkVersion` and `targetSdkVersion` in the default configuration.
-
-**Developer Note:**
-- This is a standard practice for multi-target Android projects (such as those distributed on F-Droid).
-- It ensures clarity and prevents accidental builds for the wrong Android version.
-- If you want extra convenience, you can create local shell scripts or aliases, e.g., `run-pre.sh` with `flutter run --flavor preApi30 -t lib/main.dart` for faster development.
-- Always check the README for up-to-date build instructions.
 
 ## LICENSE
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,23 +37,14 @@ android {
     }
 
     defaultConfig {
+        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "org.fossasia.badgemagic"
+        // You can update the following values to match your application needs.
+        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
+        minSdkVersion 21
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-    }
-
-    flavorDimensions "api"
-    productFlavors {
-        preApi30 {
-            dimension "api"
-            minSdkVersion 21
-            targetSdkVersion 29
-        }
-        postApi30 {
-            dimension "api"
-            minSdkVersion 30
-            targetSdkVersion 34
-        }
     }
 
     signingConfigs {


### PR DESCRIPTION
Reverts fossasia/badgemagic-app#1361

## Summary by Sourcery

Revert the multi-flavor Android builds by removing separate preApi30 and postApi30 configurations and consolidating the build, CI, and documentation into a single generic APK/AAB build process

Enhancements:
- Simplify GitHub Action for Android to build a single APK and app bundle without API-specific flavors
- Remove product flavor definitions and related configuration from android/app/build.gradle
- Clean up push workflow to drop preApi30/postApi30 build and upload steps
- Eliminate Android API flavor sections in README and streamline build instructions
- Unify screenshot action to use a single drive command without specifying flavors