### PR TITLE
issue ##1548 fixed.

### DIFF
--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -40,7 +40,6 @@ class _DrawBadgeState extends State<DrawBadge> {
 
   @override
   void dispose() {
-    _resetPortraitOrientation();
     super.dispose();
   }
 


### PR DESCRIPTION
Fixes #1548

## Changes 
- Removed _resetPortraitOrientation on dispose.

## Screenshots / Recordings  

![WhatsApp Image 2026-01-02 at 10 05 51 AM](https://github.com/user-attachments/assets/db17d9ea-31bf-4a44-accc-52ba63a6818e)




**Checklist**:
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Bug Fixes:
- Prevent unwanted portrait orientation reset when leaving the draw badge screen.