### PR TITLE
fix: Prevent Draw Clipart screen from switching to vertical layout on re-click

### DIFF
--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -128,6 +128,7 @@ class _DrawBadgeState extends State<DrawBadge> {
                 // Shape options - only show when toggled, fixed height
                 if (_showShapeOptions)
                   Container(
+                    height: 60,
                     padding: const EdgeInsets.symmetric(horizontal: 8),
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -40,7 +40,6 @@ class _DrawBadgeState extends State<DrawBadge> {
 
   @override
   void dispose() {
-    _resetPortraitOrientation();
     super.dispose();
   }
 

--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -128,7 +128,6 @@ class _DrawBadgeState extends State<DrawBadge> {
                 // Shape options - only show when toggled, fixed height
                 if (_showShapeOptions)
                   Container(
-                    height: 60,
                     padding: const EdgeInsets.symmetric(horizontal: 8),
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
Fixes #1548

## Changes 
- Removed _resetPortraitOrientation on dispose.

## Screenshots / Recordings  

![WhatsApp Image 2026-01-02 at 10 05 51 AM](https://github.com/user-attachments/assets/4eb608d9-35cf-4635-8554-09e58a2c4329)

**Checklist**:
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Bug Fixes:
- Resolve layout issue when leaving the draw badge screen by no longer resetting portrait orientation on dispose.