### PR TITLE
fix: remove unintended centering in fixed animation (#1557)

### DIFF
--- a/lib/badge_animation/ani_fixed.dart
+++ b/lib/badge_animation/ani_fixed.dart
@@ -2,17 +2,26 @@ import 'package:badgemagic/badge_animation/animation_abstract.dart';
 
 class FixedAnimation extends BadgeAnimation {
   @override
-  void processAnimation(int badgeHeight, int badgeWidth, int animationIndex,
-      List<List<bool>> processGrid, List<List<bool>> canvas) {
+  void processAnimation(
+    int badgeHeight,
+    int badgeWidth,
+    int animationIndex,
+    List<List<bool>> processGrid,
+    List<List<bool>> canvas,
+  ) {
     int newWidth = processGrid[0].length;
-    int horizontalOffset = (badgeWidth - newWidth) ~/ 2;
+
+    // Fixed animation should render content starting from the left edge
+    int horizontalOffset = 0;
 
     for (int i = 0; i < badgeHeight; i++) {
       for (int j = 0; j < badgeWidth; j++) {
         int sourceCol = j - horizontalOffset;
-        bool isWithinNewGrid = sourceCol >= 0 && sourceCol < newWidth;
-        if (isWithinNewGrid) {
+
+        if (sourceCol >= 0 && sourceCol < newWidth) {
           canvas[i][j] = processGrid[i][sourceCol];
+        } else {
+          canvas[i][j] = false;
         }
       }
     }


### PR DESCRIPTION
fixed animation was centering content using 
(badgeWidth - newWidth) ~/ 2, which introduced additional left padding.

this change removes the centering logic so content renders flush-left.

fixes #1557.

## summary by sourcery

bug fixes:
- remove unintended horizontal centering in FixedAnimation so badge content renders flush-left without extra left padding.