### PR TITLE
feat: initialize locale before runApp to prevent flicker

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,17 +23,13 @@ Future<void> main() async {
 
   // Initialize global localization service for usage outside of widgets
   final localizationService = getIt<LocalizationService>();
-  // Keep initial UI in English for integration tests that tap by English text
-  // Apply saved locale on the next frame so visible strings change after first paint
-  final saved = await localizationService.loadSavedLocale();
-  appLocale.value = const Locale('en');
-  await localizationService.init(appLocale.value ?? const Locale('en'));
-  if (saved != null && saved.languageCode != 'en') {
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      appLocale.value = saved;
-      await localizationService.updateLocale(saved);
-    });
-  }
+
+  // Load saved locale before running the app to ensure immediate correct UI
+  final savedLocale = await localizationService.loadSavedLocale();
+  final initialLocale = savedLocale ?? const Locale('en');
+
+  appLocale.value = initialLocale;
+  await localizationService.init(initialLocale);
 
   SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,


### PR DESCRIPTION
Fixes #1599 

## Changes 
- **Startup Optimization**: Moved `localizationService.loadSavedLocale()` to be awaited before `runApp` in [main.dart](lib/main.dart).
- **Locale Initialization**: Initialized `appLocale.value` with the saved locale immediately to ensure the `MaterialApp` renders the correct language on the very first frame.
- **Cleanup**: Removed the `addPostFrameCallback` hack that was previously causing a visible language flicker on startup.

## Screenshots / Recordings  
> N/A (This is a performance/timing fix for startup. It ensures the app starts in the correct language immediately without a visible flicker.)

**Checklist**:
- [x] **No hard coding**: I have used existing provider and localization patterns without hard coding values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in [lib/main.dart]
- [x] **Code analyzation**: My code passes analyzations run in `flutter analyze`.

## Summary by Sourcery

Initialize the app locale before running the Flutter app to avoid a visible language flicker on startup.

New Features:
- Initialize the application locale from the saved locale before runApp so the first rendered frame uses the correct language.

Enhancements:
- Simplify locale initialization logic by removing the post-frame locale update workaround in main.dart.