### PR TITLE
docs: fix broken fossasia link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Please talk to us on the badge-magic [Gitter channel here](https://gitter.im/fos
 ## Available Devices
 
 There are a number of devices with Bluetooth on the market. As far as we can tell they are mostly from the same manufacturer. When you get a device ensure it comes with Bluetooth. There are devices that don't support Bluetooth. These are not supported in the app currently.
-* Get one from the [FOSSASIA Shop here](https://fossasia.com/product/led-badge/)
+* Get one from the * Get one from the [FOSSASIA website](https://fossasia.org)
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Please talk to us on the badge-magic [Gitter channel here](https://gitter.im/fos
 ## Available Devices
 
 There are a number of devices with Bluetooth on the market. As far as we can tell they are mostly from the same manufacturer. When you get a device ensure it comes with Bluetooth. There are devices that don't support Bluetooth. These are not supported in the app currently.
-* Get one from the * Get one from the [FOSSASIA website](https://fossasia.org)
+* Get one from the [FOSSASIA website](https://fossasia.org)
 
 ## Screenshots
 


### PR DESCRIPTION
Fixes #1608

## Changes
- Updated the broken `fossasia.com` link in the README.
- Replaced it with `https://fossasia.org` because the old link leads to a Cloudflare 526 SSL error.

## Screenshots / Recordings
N/A

## Checklist
- [x] No hard coding used
- [x] Followed project contribution guidelines

## Summary by Sourcery

Documentation:
- Update the README to replace the outdated FOSSASIA shop link with the current FOSSASIA website URL for LED badge devices.