### PR TITLE
fix: preserve user's animation mode for single-badge transfers (#1506)

### DIFF
--- a/lib/providers/badge_message_provider.dart
+++ b/lib/providers/badge_message_provider.dart
@@ -210,14 +210,14 @@ class BadgeMessageProvider {
     Data data;
     if (jsonData != null) {
       data = fileHelper.jsonToData(jsonData);
-      if (isSavedBadge && data.messages.isNotEmpty) {
+      if (isSavedBadge && data.messages.length > 1) {
         final old = data.messages[0];
         final newMessage = Message(
           text: old.text, // use the already-padded hex string
           flash: old.flash,
           marquee: old.marquee,
           speed: old.speed,
-          mode: Mode.animation, // Force seamless marquee
+          mode: Mode.animation, // Force seamless marquee for multi-slot badges
         );
         data = Data(messages: [newMessage, ...data.messages.skip(1)]);
       }


### PR DESCRIPTION
When transferring a single saved badge, the first badge was always forced to Mode.animation (0x05) regardless of the user's saved mode. This caused wrong transitions for fixed/laser/custom animation badges.

The override was originally intended for multi-slot badge transfers (PR #1381) to create seamless continuous display cycling. It now only applies when transferring 2+ badges to fill multiple slots.

- Single-badge transfers now use correct saved mode
- Multi-slot seamless marquee behavior preserved
- Backward compatible with all existing saved badge JSON files

Fixes #1506

## Changes 
File: lib/providers/badge_message_provider.dart:222

Changed from:
if (isSavedBadge && data.messages.isNotEmpty) {
  mode: Mode.animation, // Forced on all
To:
if (isSavedBadge && data.messages.length > 1) {
  mode: Mode.animation, // Only for multi-slot

## Screenshots / Recordings  
N/A

**Checklist**: 
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

only info no error/warning
<img width="1123" height="99" alt="image" src="https://github.com/user-attachments/assets/57502dcd-fbdd-431f-9b65-16f339b786ed" />
All tests passed
<img width="1309" height="181" alt="image" src="https://github.com/user-attachments/assets/55711698-c4bc-4710-8322-749da3d2cc41" />

## Summary by Sourcery

Adjust badge transfer behavior to only force animation mode when transferring multiple saved messages, preserving the user’s chosen mode for single-badge transfers.

Bug Fixes:
- Preserve the saved display mode when transferring a single saved badge instead of always forcing animation mode.
- Restrict the seamless marquee animation override to multi-slot badge transfers with more than one message.