### PR TITLE
Add preview container to draw badge screen

### DIFF
--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -177,6 +177,20 @@ class _DrawBadgeState extends State<DrawBadge> {
                   ),
 
                 const SizedBox(height: 8),
+                Container(
+  height: 60,
+  margin: const EdgeInsets.symmetric(horizontal: 8),
+  decoration: BoxDecoration(
+    border: Border.all(color: Colors.grey),
+    borderRadius: BorderRadius.circular(8),
+  ),
+  child: const Center(
+    child: Text(
+      " Preview ",
+      style: TextStyle(fontSize: 12),
+    ),
+  ),
+),
               ],
             );
           },


### PR DESCRIPTION
Fixes #<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes 
- <!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [ ] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [ ] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

New Features:
- Introduce a bordered, labeled preview container to the Draw Badge screen layout.