### PR TITLE
chore: bump go_router from 17.0.0 to 17.2.2 and google_fonts from 6.3…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,10 +49,10 @@ dependencies:
   extended_text_field: ^16.0.2
   path_provider: ^2.1.5
   uuid: ^4.5.2
-  go_router: ^17.0.0
+  go_router: ^17.2.2
   share_plus: ^12.0.1
   file_picker: ^10.3.3
-  google_fonts: ^6.3.2
+  google_fonts: ^8.0.2
   url_launcher: ^6.3.2
   image: ^4.5.4
 


### PR DESCRIPTION
Replace PR #1581 and #1582

## Changes 
- Updated libraries at the last version available

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Update Flutter dependency versions to use the latest compatible packages.

Build:
- Bump go_router dependency from 17.0.0 to 17.2.2.
- Bump google_fonts dependency from 6.3.2 to 8.0.2.