### PR TITLE
chore: bump org.jetbrains.kotlin.android from 2.3.10 to 2.3.21

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,8 +32,8 @@ android {
     ndkVersion "28.2.13676358"
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,11 +29,11 @@ def LOCAL_KEY_PRESENT = project.hasProperty('SIGNING_KEY_FILE') && rootProject.f
 android {
     namespace "org.fossasia.badgemagic"
     compileSdk flutter.compileSdkVersion
-    ndkVersion "27.0.12077973"
+    ndkVersion "28.2.13676358"
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.13.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.3.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.21" apply false
 }
 
 include ":app"


### PR DESCRIPTION
Replace PR #1654

## Changes 
- updated org.jetbrains.kotlin.android to 2.3.21

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.