### PR TITLE
chore: bump flutter_blue_plus to last versions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,7 +29,7 @@ def LOCAL_KEY_PRESENT = project.hasProperty('SIGNING_KEY_FILE') && rootProject.f
 android {
     namespace "org.fossasia.badgemagic"
     compileSdk flutter.compileSdkVersion
-    ndkVersion "27.0.12077973"
+    ndkVersion "28.2.13676358"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/lib/bademagic_module/bluetooth/connect_state.dart
+++ b/lib/bademagic_module/bluetooth/connect_state.dart
@@ -20,7 +20,8 @@ class ConnectState extends RetryBleState {
         logger.d("No existing connection to disconnect");
       }
 
-      await scanResult.device.connect(autoConnect: false);
+      await scanResult.device
+          .connect(autoConnect: false, license: License.free);
       BluetoothConnectionState connectionState =
           await scanResult.device.connectionState.first;
 

--- a/lib/bademagic_module/utils/file_helper.dart
+++ b/lib/bademagic_module/utils/file_helper.dart
@@ -397,7 +397,7 @@ class FileHelper {
   Future<bool> importBadgeData(context) async {
     try {
       // Open file picker to select a JSON file
-      FilePickerResult? result = await FilePicker.platform.pickFiles(
+      FilePickerResult? result = await FilePicker.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['json', 'gif'],
       );

--- a/lib/bademagic_module/utils/file_helper.dart
+++ b/lib/bademagic_module/utils/file_helper.dart
@@ -397,7 +397,7 @@ class FileHelper {
   Future<bool> importBadgeData(context) async {
     try {
       // Open file picker to select a JSON file
-      FilePickerResult? result = await FilePicker.pickFiles(
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['json', 'gif'],
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.9
   provider: ^6.1.5
-  flutter_blue_plus: ^1.36.8
+  flutter_blue_plus: ^2.3.2
   logger: ^2.7.0
   flutter_svg: ^2.2.2
   get_it: ^9.0.5
@@ -51,7 +51,7 @@ dependencies:
   uuid: ^4.5.2
   go_router: ^17.2.2
   share_plus: ^12.0.1
-  file_picker: ^10.3.3
+  file_picker: ^11.0.2
   google_fonts: ^8.0.2
   url_launcher: ^6.3.2
   image: ^4.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   uuid: ^4.5.2
   go_router: ^17.2.2
   share_plus: ^12.0.1
-  file_picker: ^11.0.2
+  file_picker: ^10.3.3
   google_fonts: ^8.0.2
   url_launcher: ^6.3.2
   image: ^4.5.4


### PR DESCRIPTION
Override #1655

## Changes 
- update flutter_blue_plus library
- adapted code

> [!WARNING]  
> flutter_blue_plus ask to enter the kind of licence, [here the doc](https://pub.dev/packages/flutter_blue_plus/license). I think BadgeMagic app is free licence for non-profit organization

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Update Bluetooth and file picking dependencies and align the app code and Android build configuration with their new versions.

Enhancements:
- Adapt Bluetooth connection logic to specify the app’s free license type required by the updated flutter_blue_plus API.
- Update file import helper to use the new static file picker API from the latest file_picker package.

Build:
- Bump flutter_blue_plus and file_picker dependencies to their latest versions and update the Android NDK version in the app build configuration.