### PR TITLE
fix: large integer issue for flutter web compatibility

### DIFF
--- a/lib/view/special_text_field.dart
+++ b/lib/view/special_text_field.dart
@@ -48,6 +48,10 @@ class InlineImage extends SpecialText {
   }
 }
 
+// Sentinel start index for InlineImage runs.
+// Must stay larger than normal text indexes for web compatibility.
+const int kInlineImageSentinelStart = 0x7fffffff;
+
 class ImageBuilder extends SpecialTextSpanBuilder {
   @override
   SpecialText? createSpecialText(String flag,
@@ -58,7 +62,7 @@ class ImageBuilder extends SpecialTextSpanBuilder {
     if (flag.contains(InlineImage.flag)) {
       return InlineImage(
         textStyle,
-        start: 2147483647,
+        start: kInlineImageSentinelStart,
       );
     }
     return null;

--- a/lib/view/special_text_field.dart
+++ b/lib/view/special_text_field.dart
@@ -58,7 +58,7 @@ class ImageBuilder extends SpecialTextSpanBuilder {
     if (flag.contains(InlineImage.flag)) {
       return InlineImage(
         textStyle,
-        start: 999999999999999999,
+        start: 2147483647,
       );
     }
     return null;


### PR DESCRIPTION
## Problem

The app failed to run properly on Flutter Web because the large integer value exceeded JavaScript's safe integer limit.

## Solution

Replaced the large integer value with a web-safe integer in `special_text_field.dart`.

## Impact

* Fixes Flutter Web compatibility issue
* Prevents runtime integer overflow problems on web
* Keeps behavior consistent across platforms

## Summary by Sourcery

Replace an oversized inline image start index with a JavaScript-safe integer to restore Flutter Web compatibility and prevent overflow issues.