### PR TITLE
fix: Draw Clipart orientation reset

### DIFF
--- a/lib/view/widgets/navigation_drawer.dart
+++ b/lib/view/widgets/navigation_drawer.dart
@@ -191,10 +191,10 @@ class _BMDrawerState extends State<BMDrawer> {
         if (externalLink != null) {
           openUrl(externalLink);
         } else if (shareText != null) {
-          Share.share(shareText);
+          SharePlus.instance.share(ShareParams(text: shareText));
         } else {
           if (ModalRoute.of(context)?.settings.name == routeName) {
-            Navigator.pushReplacementNamed(context, routeName);
+            return;
           } else {
             Navigator.pushNamedAndRemoveUntil(
               context,


### PR DESCRIPTION
Fixes #1712

## Changes
- Added a route check in the Drawer to prevent creating a new screen instance when the target screen is already active, preserving the current state and fixing the Draw Clipart orientation reset issue.
- Updated the Share API to use `SharePlus.instance.share` with `ShareParams`, ensuring compatibility with the latest `share_plus` package.

## Screenshots / Recordings  
[Screen_recording_20260521_121426.webm](https://github.com/user-attachments/assets/1b10b37f-8604-4a78-a42c-5ac5b4bd1338)


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Prevent redundant navigation when reselecting the current route from the drawer and update sharing to the latest share_plus API.

Bug Fixes:
- Avoid recreating the current screen when its drawer item is tapped, preserving existing state (e.g., Draw Clipart orientation).

Enhancements:
- Migrate drawer sharing action to use SharePlus.instance.share with ShareParams for compatibility with newer share_plus versions.