### PR TITLE
fix: global theme for dialog and textbuttons style

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,6 +78,28 @@ class MyApp extends StatelessWidget {
               theme: ThemeData(
                 colorSchemeSeed: Colors.white,
                 useMaterial3: true,
+                dialogTheme: DialogThemeData(
+                  backgroundColor: Colors.white,
+                  surfaceTintColor: Colors.transparent,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(28.0),
+                  ),
+                  actionsPadding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  titleTextStyle: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 18,
+                    color: Colors.black,
+                  ),
+                ),
+                textButtonTheme: TextButtonThemeData(
+                  style: TextButton.styleFrom(
+                    foregroundColor: Colors.red,
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                    padding: const EdgeInsets.all(15),
+                  ),
+                ),
               ),
               locale: locale ?? const Locale('en', 'US'),
               localizationsDelegates: const [


### PR DESCRIPTION
Fixes #1646 
Closed for error #1647

## Changes 
I had proposed a change on epaper regarding the app's theme, inserting the theme the popups and buttons should have in the main app, so I copied and pasted the same suggestion since the apps are similar, and the result is good!

I notice that the three apps have a very similar theme (you could say they have the same theme). What if, instead of changing the configuration each time, we created a theme in the main app that was global to the apps and adapted the apps to this theme? I know this isn't the best approach in Flutter, but the best thing to do is create reusable components. However, creating a global theme doesn't prevent you from creating reusable components, and in my opinion, it's a simple and effective solution.

## Screenshots / Recordings  
<img width="442" height="214" alt="image" src="https://github.com/user-attachments/assets/4a3213f1-8093-4d6b-8d7b-429d2b4ffea0" />

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Define a global dialog and text button theme in the main app theme configuration to standardize popup and button appearance across the app.

Enhancements:
- Configure a shared DialogThemeData in the main ThemeData to unify dialog styling.
- Configure a shared TextButtonThemeData in the main ThemeData to standardize text button appearance.