### PR TITLE
fix: renamed the "animation" transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Badge Magic app is a comprehensive LED badge management system that lets you
 - **Animation Mode**: Advanced animations including Pacman, hearts, fireworks, and more
 
 ### 🎭 **Animation & Effects**
-- **22 Animation Types**: Left, Right, Up, Down, Fixed, Snowflake, Picture, Laser, Pacman, Chevron, Diamond, Broken Hearts, Cupid, Feet, Fish, Diagonal, Emergency, Beating Hearts, Fireworks, Digital Rain (Equalizer), and Cycle
+- **22 Animation Types**: Left, Right, Up, Down, Fixed, Splitting, Snowflake, Picture, Laser, Pacman, Chevron, Diamond, Broken Hearts, Cupid, Feet, Fish, Diagonal, Emergency, Beating Hearts, Fireworks, Digital Rain (Equalizer), and Cycle
 - **3 Visual Effects**: Flash, Invert, and Marquee
 - **Speed Control**: 8-speed radial dial for precise animation timing
 - **Transition Tab**: Quick access to basic animations

--- a/lib/badge_animation/ani_splitting.dart
+++ b/lib/badge_animation/ani_splitting.dart
@@ -1,6 +1,6 @@
 import 'package:badgemagic/badge_animation/animation_abstract.dart';
 
-class AniAnimation extends BadgeAnimation {
+class SplittingAnimation extends BadgeAnimation {
   @override
   void processAnimation(int badgeHeight, int badgeWidth, int animationIndex,
       List<List<bool>> processGrid, List<List<bool>> canvas) {

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -25,7 +25,7 @@ const Color dividerColor = Color(0xFFE0E0E0);
 const Color drawerHeaderTitle = Color(0xFFFFFFFF);
 
 //path to all the animation assets used
-const String animation = 'assets/animations/ic_anim_animation.gif';
+const String aniSplitting = 'assets/animations/ic_anim_animation.gif';
 const String aniLeft = 'assets/animations/ic_anim_left.gif';
 const String aniDown = 'assets/animations/ic_anim_down.gif';
 const String aniFixed = 'assets/animations/ic_anim_fixed.gif';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -63,6 +63,7 @@
   "speed": "Speed",
   "speedTitle": "Speed",
   "animation": "Animation",
+  "animationSplitting": "Splitting",
   "transition": "Transition",
   "transitionTitle": "Transition",
   "effects": "Effects",

--- a/lib/providers/animation_badge_provider.dart
+++ b/lib/providers/animation_badge_provider.dart
@@ -4,7 +4,7 @@ import 'package:badgemagic/providers/imageprovider.dart';
 import 'package:badgemagic/providers/speed_dial_provider.dart';
 import 'package:badgemagic/bademagic_module/utils/byte_array_utils.dart';
 import 'package:badgemagic/bademagic_module/utils/converters.dart';
-import 'package:badgemagic/badge_animation/ani_animation.dart';
+import 'package:badgemagic/badge_animation/ani_splitting.dart';
 import 'package:badgemagic/badge_animation/ani_down.dart';
 import 'package:badgemagic/badge_animation/ani_fixed.dart';
 import 'package:badgemagic/badge_animation/ani_laser.dart';
@@ -40,7 +40,7 @@ Map<int, BadgeAnimation?> animationMap = {
   2: UpAnimation(),
   3: DownAnimation(),
   4: FixedAnimation(),
-  5: AniAnimation(),
+  5: SplittingAnimation(),
   6: SnowFlakeAnimation(),
   7: PictureAnimation(),
   8: LaserAnimation(),

--- a/lib/view/save_badge_screen.dart
+++ b/lib/view/save_badge_screen.dart
@@ -4,7 +4,7 @@ import 'package:badgemagic/bademagic_module/utils/byte_array_utils.dart';
 import 'package:badgemagic/bademagic_module/utils/converters.dart';
 import 'package:badgemagic/bademagic_module/utils/file_helper.dart';
 import 'package:badgemagic/bademagic_module/utils/toast_utils.dart';
-import 'package:badgemagic/badge_animation/ani_animation.dart';
+import 'package:badgemagic/badge_animation/ani_splitting.dart';
 import 'package:badgemagic/badge_animation/ani_fixed.dart';
 import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/services/localization_service.dart';
@@ -239,8 +239,8 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                                                   (msg) => msg.text.isNotEmpty)
                                               .length >
                                           1) {
-                                        animationBadgeProvider
-                                            .setAnimationMode(AniAnimation());
+                                        animationBadgeProvider.setAnimationMode(
+                                            SplittingAnimation());
                                       } else {
                                         animationBadgeProvider
                                             .setAnimationMode(FixedAnimation());

--- a/lib/view/widgets/transitiontab.dart
+++ b/lib/view/widgets/transitiontab.dart
@@ -70,8 +70,8 @@ class _TransitionTabState extends State<TransitionTab> {
               ),
               Expanded(
                 child: AniContainer(
-                  animation: animation,
-                  animationName: l10n.animation,
+                  animation: aniSplitting,
+                  animationName: l10n.animationSplitting,
                   index: 5,
                 ),
               ),


### PR DESCRIPTION
Fixes #1749

## Changes 
- renamed the "animation" transition and updated readme

## Screenshots / Recordings  
<img width="527" height="321" alt="image" src="https://github.com/user-attachments/assets/6b928ca2-ccb0-49e7-9c89-a21ddfd96371" />

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Rename the generic "animation" transition to "Splitting" across the app for consistency and clarity.

Bug Fixes:
- Correct the mapping and labeling of the "animation" transition so it appears as "Splitting" in the UI and uses the appropriate animation implementation.

Documentation:
- Update the README to list "Splitting" as one of the available animation types.