### PR TITLE
fix: remove verbose Animation Index log from getAnimationIndex()

### DIFF
--- a/lib/providers/animation_badge_provider.dart
+++ b/lib/providers/animation_badge_provider.dart
@@ -218,7 +218,6 @@ class AnimationBadgeProvider extends ChangeNotifier {
   int? getAnimationIndex() {
     for (var animation in animationMap.entries) {
       if (animation.value != null && animation.value == _currentAnimation) {
-        logger.i("Animation Index: ${animation.key}");
         return animation.key;
       }
     }


### PR DESCRIPTION
fix : #1786  

Overview
Hi! This PR fixes the issue where the debug console gets completely flooded with "Animation Index: X" log messages while animations are running. It was making it nearly impossible to read other important logs or trace errors during active debugging sessions.

 What was happening? (Root Cause)
Inside lib/providers/animation_badge_provider.dart, the getAnimationIndex() method had an active logger.i() statement. 

Since this method gets called on every single animation frame render cycle to figure out which frame to draw, it was firing hundreds of times per second. This caused a heavy stream of log spam in the console, adding unnecessary overhead and a lot of frustration while inspecting local logs.


 The Fix
- Removed the frame-level log: I have completely removed the logger.i line from the loop inside getAnimationIndex(). 
- Kept the useful state log: We already have a single log inside setAnimationMode() that triggers only when the animation mode actually changes. That is more than enough for debugging transitions, so we do not lose any meaningful telemetry.


## Code Diff

---diff
  int? getAnimationIndex() {
    for (var animation in animationMap.entries) {
      if (animation.value != null && animation.value == _currentAnimation) {
-       logger.i("Animation Index: ${animation.key}");------- remove this one line 
        return animation.key;
      }
    }
    return 0;
  }
<img width="952" height="242" alt="image" src="https://github.com/user-attachments/assets/422c24af-82ab-4757-b616-8e5b33d94d2d" />
