### PR TITLE
fix: resolve text clipping and animation lookup issue #1796

### DIFF
--- a/lib/badge_animation/ani_fixed.dart
+++ b/lib/badge_animation/ani_fixed.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:badgemagic/badge_animation/animation_abstract.dart';
 
 class FixedAnimation extends BadgeAnimation {
@@ -5,7 +6,7 @@ class FixedAnimation extends BadgeAnimation {
   void processAnimation(int badgeHeight, int badgeWidth, int animationIndex,
       List<List<bool>> processGrid, List<List<bool>> canvas) {
     int newWidth = processGrid[0].length;
-    int horizontalOffset = (badgeWidth - newWidth) ~/ 2;
+    int horizontalOffset = max(0, (badgeWidth - newWidth) ~/ 2);
 
     for (int i = 0; i < badgeHeight; i++) {
       for (int j = 0; j < badgeWidth; j++) {

--- a/lib/badge_animation/animation_abstract.dart
+++ b/lib/badge_animation/animation_abstract.dart
@@ -1,4 +1,10 @@
 abstract class BadgeAnimation {
   void processAnimation(int badgeHeight, int badgeWidth, int animationIndex,
       List<List<bool>> processGrid, List<List<bool>> canvas);
+
+  @override
+  bool operator ==(Object other) => runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
 }

--- a/lib/providers/animation_badge_provider.dart
+++ b/lib/providers/animation_badge_provider.dart
@@ -218,10 +218,11 @@ class AnimationBadgeProvider extends ChangeNotifier {
   int? getAnimationIndex() {
     for (var animation in animationMap.entries) {
       if (animation.value != null && animation.value == _currentAnimation) {
+        logger.i("Animation Index: ${animation.key}");
         return animation.key;
       }
     }
-    return 0;
+    return null;
   }
 
   bool isAnimationActive(BadgeAnimation? badgeAnimation) {
@@ -233,7 +234,8 @@ class AnimationBadgeProvider extends ChangeNotifier {
       String message, Converters converters, bool isInverted) async {
     bool isSpecial = isSpecialAnimationSelected();
     if (message.isEmpty && !isSpecial) {
-      stopAllAnimations();
+      _timer?.cancel();
+      _animationIndex = 0;
       List<List<bool>> emptyGrid =
           List.generate(11, (i) => List.generate(44, (j) => false));
       _newGrid = emptyGrid;


### PR DESCRIPTION
Closes #1796

## Fix "Fixed" Animation Bug

This PR fixes the issue where the **Fixed** animation doesn't behave as expected. Instead of remaining fixed, it can clip the text and may even get transferred as the **Splitting** animation.

### What was causing the issue?

The app was identifying the selected animation by comparing object instances (`==`). This works only when the exact same instance is reused. If a new instance of the same animation class is created, the comparison fails, causing the app to fall back to the wrong animation during transfer.

### What's changed?

I updated `lib/badge_animation/animation_abstract.dart` to make animation comparisons based on the animation type instead of object identity.

By overriding `==` and `hashCode` in the `BadgeAnimation` base class to compare `runtimeType`, different instances of the same animation (for example, two `FixedAnimation` objects) are now treated as equal.

This ensures the correct animation is recognized and transferred, preventing the unexpected fallback behavior.

https://github.com/user-attachments/assets/a52ec0b7-ae5e-45a1-a55b-994562cc5ee8

## Summary by Sourcery

Adjust badge animation handling to correctly identify and apply fixed animations without clipping or unintended fallbacks.

Bug Fixes:
- Ensure fixed badge animations are identified by type rather than instance to prevent incorrect animation transfers.
- Prevent fixed animation text clipping by clamping the horizontal offset to non-negative values.
- Avoid incorrectly defaulting to an animation index when no current animation is found, allowing proper handling of the idle state.
- Stop badge animations cleanly when no message and no special animation are selected by cancelling timers and resetting the animation index.